### PR TITLE
Add BSP generation script with STM32F4 template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
- 
  # What is KDOS?
  
  KDOS is a simple co-operative task switcher. It allows different parts of the
@@ -63,3 +62,12 @@
  Implemented message queue overflow detection (kdos.h and Kdos.c).
  Added stub functions and their declarations (kmulti.c and KMulti.h, comment-stripped).
  Conceptually reviewed atomicity concerns and the TaskSwitchPermit logic, with suggestions for future comments.
+
+## BSP generation
+Use `scripts/kdos_config.py` to generate a board support package skeleton. Run:
+
+```bash
+python scripts/kdos_config.py stm32f4 -o bsp_stm32f4.c
+```
+
+This creates `bsp_stm32f4.c` from the STM32F4 template which implements the required `k_hal` functions for that controller.

--- a/scripts/kdos_config.py
+++ b/scripts/kdos_config.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+import argparse
+
+TEMPLATES = {
+    "stm32f4": os.path.join("templates", "stm32f4", "bsp.c"),
+}
+
+def list_targets():
+    print("Available controllers:")
+    for key in TEMPLATES:
+        print(f"  - {key}")
+
+
+def generate(target, out_file):
+    template = TEMPLATES.get(target.lower())
+    if not template or not os.path.exists(template):
+        print(f"Controller '{target}' not supported.")
+        return
+    shutil.copy(template, out_file)
+    print(f"Generated {out_file} from template {template}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="KDOS BSP generator")
+    parser.add_argument("target", nargs="?", help="Target controller identifier")
+    parser.add_argument("-o", "--output", default="bsp_mycpu.c", help="Output file")
+    args = parser.parse_args()
+
+    if not args.target:
+        list_targets()
+        return
+
+    generate(args.target, args.output)
+
+if __name__ == "__main__":
+    main()

--- a/templates/stm32f4/bsp.c
+++ b/templates/stm32f4/bsp.c
@@ -1,0 +1,74 @@
+#include "k_hal.h"
+#include "stm32f4xx.h"
+
+void K_HAL_DisableInterrupts(void)
+{
+    __disable_irq();
+}
+
+void K_HAL_EnableInterrupts(void)
+{
+    __enable_irq();
+}
+
+void *K_HAL_InitTaskStack(void *p_stack_base,
+                          unsigned int stack_size_bytes,
+                          void (*task_func_addr)(WORD, WORD, LONG),
+                          void (*task_exit_handler_addr)(WORD),
+                          WORD initial_msg_type,
+                          WORD initial_sparam,
+                          LONG initial_lparam)
+{
+    uint32_t *sp = (uint32_t *)((uint8_t *)p_stack_base + stack_size_bytes);
+    sp = (uint32_t *)((uint32_t)sp & ~0x7U); /* 8-byte alignment */
+
+    /* Automatic stacking as performed on exception entry */
+    *--sp = 0x01000000U;                 /* xPSR */
+    *--sp = (uint32_t)task_func_addr;     /* PC */
+    *--sp = (uint32_t)task_exit_handler_addr; /* LR */
+    *--sp = 0; /* R12 */
+    *--sp = 0; /* R3 */
+    *--sp = initial_lparam; /* R2 */
+    *--sp = initial_sparam; /* R1 */
+    *--sp = initial_msg_type; /* R0 */
+
+    /* Remaining registers R4-R11 saved by context switch */
+    for (int i = 0; i < 8; ++i) {
+        *--sp = 0;
+    }
+
+    return sp;
+}
+
+__attribute__((naked)) void K_HAL_ContextSwitch(void **current_sp_storage, void *next_sp)
+{
+    __asm volatile (
+        "mrs r2, psp\n"           /* Get current process stack pointer */
+        "stmdb r2!, {r4-r11}\n"  /* Save callee-saved registers */
+        "str r2, [r0]\n"        /* Store current SP */
+        "ldr r2, [r1]\n"        /* Load next SP */
+        "ldmia r2!, {r4-r11}\n" /* Restore callee-saved regs */
+        "msr psp, r2\n"         /* Set PSP to new task */
+        "bx lr\n"               /* Return */
+    );
+}
+
+__attribute__((naked)) void K_HAL_StartScheduler(void *first_task_sp)
+{
+    __asm volatile (
+        "msr psp, %0\n"          /* Set PSP to task stack */
+        "movs r0, #2\n"
+        "msr CONTROL, r0\n"      /* Switch to PSP */
+        "isb\n"
+        "pop {r4-r11}\n"        /* Pop initial r4-r11 */
+        "pop {r0-r3, r12, lr, pc}\n" /* Pop remaining regs and start task */
+        : : "r" (first_task_sp) : "memory"
+    );
+    for(;;);
+}
+
+void K_HAL_InitSystemTimer(void (*isr)(void))
+{
+    SysTick_Config(SystemCoreClock / 1000);
+    (void)isr; /* vector table should point to isr */
+}


### PR DESCRIPTION
## Summary
- add `kdos_config.py` front-end for generating BSP skeletons
- provide STM32F4 HAL implementation template
- document BSP generation usage in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68718e565478832f994883ff6de2ee6b