### PR TITLE
fix: replace anchor links in CONTRIBUTING.md TOC with plain text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,14 +3,14 @@
 Thank you for your interest in contributing to KTOS! This document provides guidelines and instructions for contributing to our tiny cooperative RTOS alternative.
 
 ## Table of Contents
-- [Code of Conduct](#code-of-conduct)
-- [Getting Started](#getting-started)
-- [Development Workflow](#development-workflow)
-- [Adding a New BSP](#adding-a-new-bsp)
-- [Coding Standards](#coding-standards)
-- [Commit Guidelines](#commit-guidelines)
-- [Pull Request Process](#pull-request-process)
-- [Testing](#testing)
+- Code of Conduct
+- Getting Started
+- Development Workflow
+- Adding a New BSP
+- Coding Standards
+- Commit Guidelines
+- Pull Request Process
+- Testing
 
 ## Code of Conduct
 


### PR DESCRIPTION
  Doxygen 1.9.8 treats [text](#anchor) links as \ref commands.
  Hyphenated anchor names like code-of-conduct are not valid Doxygen
  identifiers so it aborts with WARN_AS_ERROR=YES. Plain text TOC
  entries have no \ref resolution issue.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Tested on hardware platform: <!-- specify which MCU/board -->
- [ ] Unit tests added/updated
- [ ] All existing tests pass
- [ ] Code compiles without warnings

**Test Configuration**:
* MCU/Platform:
* Compiler version:
* Toolchain:

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the pull request here -->

## Related Issues
<!-- Link related issues below. Use "Closes #XX" if this PR closes an issue -->
