### PR TITLE
feat: add Arduino Mega 2560 bare-metal KTOS examples

### DIFF
--- a/examples/Arduino/Mega/README.md
+++ b/examples/Arduino/Mega/README.md
@@ -1,0 +1,233 @@
+### KTOS on Arduino Mega 2560 — Bare-Metal Examples
+
+Six examples that run on the **Arduino Mega 2560 (ATmega2560)** with
+**KTOS as the operating system** — no Arduino framework, no Arduino
+runtime, no `setup()` / `loop()`.  Every example provides its own
+`main()`, talks to USART0, ADC, TWI, SPI, and GPIO through **direct AVR
+register access**, and hands the CPU to `ktos_RunOS()` which never
+returns.
+
+Where it makes sense, examples are split across **two cooperating
+tasks** that communicate exclusively through `ktos_SendMsg()` — exactly
+the pattern the ESP8266 KTOS examples use.
+
+---
+
+## Why bare-metal?
+
+The Arduino framework adds overhead for `Serial`, `Wire`, `SPI`,
+`analogRead`, and the `loop()` runtime.  On a 256 KB / 8 KB chip
+that matters less than on the Nano, but the register-level code is
+far more readable and leaves KTOS visibly in charge of the CPU.
+
+| Example                                         | KTOS feature exercised                                         |
+|-------------------------------------------------|----------------------------------------------------------------|
+| [`uart/`](uart/README.md)                       | **Two tasks**, line-assembler hands lines to command processor |
+| [`led_control/`](led_control/README.md)         | **Two tasks**, `ktos_SendMsg(MSG_SET_MODE)` from UART to LED   |
+| [`button_control/`](button_control/README.md)   | **Two tasks**, debouncer publishes `MSG_BUTTON_EVENT` to UI    |
+| [`adc/`](adc/README.md)                         | Single task, 1 Hz timer wake — `return 1000;`                 |
+| [`i2c/`](i2c/README.md)                         | Single task, 5 s timer wake doing TWI scan                     |
+| [`spi/`](spi/README.md)                         | Single task, MOSI→MISO loopback self-test every 1 s            |
+
+---
+
+## Board Overview
+
+| Item              | Value                                                       |
+|-------------------|-------------------------------------------------------------|
+| Board             | Arduino Mega 2560                                           |
+| MCU               | ATmega2560 (AVR 8-bit)                                      |
+| Clock             | 16 MHz                                                      |
+| Logic level       | 5 V                                                         |
+| Flash             | 256 KB                                                      |
+| SRAM              | 8 KB                                                        |
+| EEPROM            | 4 KB                                                        |
+| KTOS BSP          | `bsp/atmega2560/`                                           |
+| KTOS tick source  | Timer1 CTC, 1 ms                                            |
+| Toolchain         | avr-gcc + avr-libc (no Arduino framework)                   |
+| Upload protocol   | `wiring` (STK500v2)                                         |
+| Monitor baud      | 115200, 8N1                                                 |
+
+> **Important:** The ATmega2560 has a 3-byte (22-bit) program counter.
+> The KTOS BSP (`bsp/atmega2560/ktos_bsp.c`) accounts for this in
+> `ktos_hal_InitTaskStack()` — the top three bytes of every new task's
+> stack frame encode the 22-bit return address correctly.
+
+---
+
+## ATmega2560 → Mega 2560 Pin Map
+
+Several pins differ from the Nano/Uno — these are the ones used by
+the examples.
+
+| Mega label  | AVR pin  | Used by                      | Register bit                      |
+|-------------|----------|------------------------------|-----------------------------------|
+| `D0 / RX0`  | `PE0`    | UART RX (USART0)             | `UDR0` (auto-controlled)          |
+| `D1 / TX0`  | `PE1`    | UART TX (USART0)             | `UDR0` (auto-controlled)          |
+| `D2`        | `PE4`    | Button (`button_control`)    | `PINE` bit 4 / `PORTE` bit 4      |
+| `D13`       | `PB7`    | LED (`led_control`)          | `DDRB` / `PORTB` bit 7            |
+| `A0`        | `PF0`    | ADC channel 0 (`adc`)        | `ADMUX` ch 0, read `ADC`          |
+| `D20 / SDA` | `PD1`    | I²C SDA (`i2c`)              | `SDA` of TWI peripheral           |
+| `D21 / SCL` | `PD0`    | I²C SCL (`i2c`)              | `SCL` of TWI peripheral           |
+| `D50`       | `PB3`    | SPI MISO (`spi`)             | `DDRB` / `PORTB` bit 3 (input)    |
+| `D51`       | `PB2`    | SPI MOSI (`spi`)             | `DDRB` / `PORTB` bit 2            |
+| `D52`       | `PB1`    | SPI SCK  (`spi`)             | `DDRB` / `PORTB` bit 1            |
+| `D53`       | `PB0`    | SPI SS   (`spi`)             | `DDRB` / `PORTB` bit 0            |
+
+> **Note:** D13 is **PB7** on the Mega 2560 — not PB5 as on the Uno/Nano.
+> D2 is **PE4** on the Mega 2560 — not PD2.
+> SCK is **PB1/D52**, so D13 does **not** flicker during SPI transfers.
+
+---
+
+## Common Setup
+
+### 1. Install PlatformIO
+
+**VS Code (recommended):**
+
+1. Install [Visual Studio Code](https://code.visualstudio.com/).
+2. Install the **PlatformIO IDE** extension.
+3. Reload VS Code when prompted.
+
+**Command line:**
+
+```bash
+python3 -m pip install --user platformio
+pio --version
+```
+
+### 2. Open an example
+
+```bash
+cd examples/Arduino/Mega/adc          # or any other example folder
+```
+
+In VS Code: `File → Open Folder…` and select the example directory.
+
+### 3. Build and upload
+
+```bash
+pio run                 # compile
+pio run -t upload       # flash via USB (STK500v2 / wiring protocol)
+```
+
+### 4. Open the serial monitor
+
+```bash
+pio device monitor -b 115200
+```
+
+Press the Mega's reset button if no banner appears.
+
+---
+
+## What gets compiled
+
+Each example's `platformio.ini` is deliberately minimal — **no
+framework**, just the AVR platform plus the KTOS sources:
+
+```ini
+[env:megaatmega2560]
+platform        = atmelavr
+board           = megaatmega2560
+upload_protocol = wiring
+monitor_speed   = 115200
+build_src_filter =
+    +<*>
+    +<../../../../../core/ktos.c>
+    +<../../../../../bsp/atmega2560/ktos_bsp.c>
+build_flags =
+    -Os -Wall -Wextra
+    -I../../../../core
+    -I../../../../bsp/atmega2560
+```
+
+- `core/ktos.c` — the platform-independent KTOS scheduler.
+- `bsp/atmega2560/ktos_bsp.c` — Timer1 init, **3-byte PC** context
+  switch, stack frame builder.
+
+No Arduino framework is pulled in.  The only runtime is **avr-libc**
+which avr-gcc links automatically.
+
+---
+
+## Anatomy of a KTOS bare-metal example
+
+Every `main.c` in this folder follows the same skeleton:
+
+```c
+#include "../../../../../core/ktos.h"
+#include <avr/io.h>
+#include <avr/interrupt.h>
+
+/* 1. Bare-metal peripheral driver(s) — direct register access ------- */
+static void uart_init(void)   { /* UBRR0H/L, UCSR0A/B/C */ }
+static void uart_putc(char c) { while (!(UCSR0A & (1<<UDRE0))); UDR0 = c; }
+
+/* 2. KTOS platform callbacks ---------------------------------------- */
+__attribute__((noreturn))
+void ktos_Emergency(const char *msg) {
+    uart_puts("[FATAL] "); uart_puts(msg); while (1);
+}
+void ktos_DebugPrintf(const char *f, ...) { (void)f; }
+void ktos_InitSys(void) { }
+
+/* 3. KTOS 1 ms tick — Timer1 CTC, set up by the ATmega2560 BSP ----- */
+ISR(TIMER1_COMPA_vect) { ktos_timer_irq_handler(); }
+
+/* 4. Your task(s) --------------------------------------------------- */
+static WORD my_task(WORD MsgType, WORD sParam, LONG lParam) {
+    switch (MsgType) {
+        case KTOS_MSG_TYPE_INIT:  /* one-shot init  */ break;
+        case KTOS_MSG_TYPE_TIMER: /* periodic work  */ break;
+        /* user messages from ktos_SendMsg() land here */
+    }
+    return 1000;   /* sleep 1 s then deliver KTOS_MSG_TYPE_TIMER */
+}
+
+/* 5. main() — register tasks, give the CPU to KTOS forever ---------- */
+int main(void) {
+    uart_init();
+    ktos_InitTask(my_task, /*stack words=*/96, /*queue=*/4, 'T');
+    ktos_RunOS();         /* never returns */
+    return 0;             /* unreachable   */
+}
+```
+
+Key points:
+
+- **No `setup()` / `loop()`.**  KTOS provides the main loop; the
+  application provides plain C `main()`.
+- **Timer1 is KTOS's tick.**  The ATmega2560 BSP configures Timer1 CTC
+  for a 1 ms interrupt; `ISR(TIMER1_COMPA_vect)` hands control to
+  `ktos_timer_irq_handler()`.
+- **Tasks never block.**  Return a sleep value in ms (or `MSG_WAIT` for
+  "wake me only when a message arrives").
+- **Cooperative ⇒ no mutexes.**  Two tasks cannot run simultaneously,
+  so shared globals need no lock.
+
+---
+
+## Notes on the SPI Loopback Example
+
+The `spi/` example requires a single jumper wire connecting **D51
+(MOSI)** to **D50 (MISO)**.  It transmits the pattern
+`{0xA5, 0x5A, 0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0xFF}` and compares the
+received bytes.  Because SCK is on D52 (PB1) rather than D13 (PB7),
+the on-board LED does not flicker during transfers.
+
+---
+
+## Troubleshooting
+
+| Symptom                                                | Likely cause                       | Fix                                                                              |
+|--------------------------------------------------------|------------------------------------|----------------------------------------------------------------------------------|
+| `avrdude: stk500v2_ReceiveMessage(): timeout`          | Wrong upload protocol or port      | Confirm `upload_protocol = wiring` and the correct COM port                      |
+| Board not listed by `pio device list`                  | Missing USB driver                 | Install the CH340 driver if using a clone board                                  |
+| Garbled serial output                                  | Wrong baud rate                    | Set monitor to **115200**, 8N1                                                   |
+| Banner prints but tasks never fire                     | Timer1 ISR not hooked up           | Confirm `ISR(TIMER1_COMPA_vect)` is present in `main.c`                          |
+| SPI: `Loopback FAIL`                                   | Jumper missing or reversed         | Connect D51 to D50 with a single wire                                            |
+| Button: no events                                      | Wrong pin                          | D2 on the Mega is **PE4**, not PD2 — use `PINE`/`PORTE`/`DDRE`                  |
+| I²C scan: all `No devices found`                       | Missing pull-ups                   | Add 4.7 kΩ pull-up resistors from SDA (D20) and SCL (D21) to 5 V                |
+| `[KTOS FATAL]` on boot                                 | Heap exhausted creating a task     | Reduce the `StackSize` argument(s) to `ktos_InitTask()`                          |

--- a/examples/Arduino/Mega/adc/platformio.ini
+++ b/examples/Arduino/Mega/adc/platformio.ini
@@ -1,0 +1,22 @@
+; KTOS — Arduino Mega 2560 ADC example (bare-metal, no Arduino framework)
+;
+; Single KTOS task reads ADC channel 0 (A0 / PF0) once per second
+; and prints the raw value and millivolt reading over USART0.
+
+[env:megaatmega2560]
+platform        = atmelavr
+board           = megaatmega2560
+upload_protocol = wiring
+monitor_speed   = 115200
+
+build_src_filter =
+    +<*>
+    +<../../../../../core/ktos.c>
+    +<../../../../../bsp/atmega2560/ktos_bsp.c>
+
+build_flags =
+    -Os
+    -Wall
+    -Wextra
+    -I../../../../core
+    -I../../../../bsp/atmega2560

--- a/examples/Arduino/Mega/adc/src/main.c
+++ b/examples/Arduino/Mega/adc/src/main.c
@@ -1,0 +1,132 @@
+/*
+ * KTOS — Arduino Mega 2560 ADC example (bare-metal)
+ *
+ * A single KTOS task drives the whole program:
+ *
+ *   KTOS_MSG_TYPE_INIT   -> print banner, configure ADC
+ *   KTOS_MSG_TYPE_TIMER  -> read ADC channel 0 (A0 / PF0), print raw
+ *                           value and millivolts, sleep 1000 ms
+ *
+ * No Arduino framework, no analogRead — just AVR registers and KTOS.
+ * Voltage is reported in millivolts to avoid floating-point printf.
+ *
+ * A0 on the Mega 2560 = PF0 (same ADC channel 0 as on the Nano/Uno).
+ */
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <stdint.h>
+
+#include "../../../../../core/ktos.h"
+
+/* =========================================================================
+ * USART0 — 115200 8N1 (U2X0=1, UBRR0=16)
+ * ========================================================================= */
+
+static void uart_init(void)
+{
+    UBRR0H = 0;
+    UBRR0L = 16;
+    UCSR0A = (1 << U2X0);
+    UCSR0B = (1 << TXEN0) | (1 << RXEN0);
+    UCSR0C = (1 << UCSZ01) | (1 << UCSZ00);
+}
+
+static void uart_putc(char c)
+{
+    while (!(UCSR0A & (1 << UDRE0))) { }
+    UDR0 = (uint8_t)c;
+}
+
+static void uart_puts(const char *s)
+{
+    while (*s) { uart_putc(*s++); }
+}
+
+static void uart_putu32(uint32_t n)
+{
+    char buf[10];
+    uint8_t i = 0;
+    if (n == 0) { uart_putc('0'); return; }
+    while (n) { buf[i++] = (char)('0' + n % 10); n /= 10; }
+    while (i--) { uart_putc(buf[i]); }
+}
+
+/* =========================================================================
+ * ADC — channel 0 (A0 / PF0), AVCC reference, 10-bit
+ * ========================================================================= */
+
+static void adc_init(void)
+{
+    ADMUX  = (1 << REFS0);                               /* AVCC ref, ch 0 */
+    ADCSRA = (1 << ADEN) | (1 << ADPS2) | (1 << ADPS1) | (1 << ADPS0);
+                                                          /* enable, prescaler 128 */
+}
+
+static uint16_t adc_read(void)
+{
+    ADCSRA |= (1 << ADSC);
+    while (ADCSRA & (1 << ADSC)) { }
+    return ADC;
+}
+
+/* =========================================================================
+ * KTOS platform callbacks
+ * ========================================================================= */
+
+__attribute__((noreturn))
+void ktos_Emergency(const char *msg)
+{
+    uart_puts("\r\n[KTOS FATAL] ");
+    uart_puts(msg);
+    uart_puts("\r\n");
+    while (1) { }
+}
+
+void ktos_DebugPrintf(const char *fmt, ...) { (void)fmt; }
+void ktos_InitSys(void) { }
+
+ISR(TIMER1_COMPA_vect) { ktos_timer_irq_handler(); }
+
+/* =========================================================================
+ * ADC task
+ * ========================================================================= */
+
+static WORD adc_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam;
+    (void)lParam;
+
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        adc_init();
+        uart_puts("=============================\r\n");
+        uart_puts("  KTOS ADC Example\r\n");
+        uart_puts("  Arduino Mega 2560\r\n");
+        uart_puts("=============================\r\n");
+        uart_puts("Reading A0 (PF0) every 1 s\r\n");
+        return 1000;
+    }
+
+    uint16_t raw = adc_read();
+    uint32_t mv  = ((uint32_t)raw * 5000UL) / 1023UL;
+
+    uart_puts("A0: raw=");
+    uart_putu32(raw);
+    uart_puts("  ");
+    uart_putu32(mv);
+    uart_puts(" mV\r\n");
+
+    return 1000;
+}
+
+/* =========================================================================
+ * Entry point
+ * ========================================================================= */
+
+int main(void)
+{
+    uart_init();
+    ktos_InitTask(adc_task, 96, 4, 'A');
+    ktos_RunOS();
+    return 0;
+}

--- a/examples/Arduino/Mega/button_control/platformio.ini
+++ b/examples/Arduino/Mega/button_control/platformio.ini
@@ -1,0 +1,23 @@
+; KTOS — Arduino Mega 2560 button control example (bare-metal, no Arduino framework)
+;
+; Two KTOS tasks:
+;   button_task -> polls D2 (PE4) every 5 ms, debounces, posts MSG_BUTTON_EVENT
+;   ui_task     -> prints "Button pressed / released" on MSG_BUTTON_EVENT
+
+[env:megaatmega2560]
+platform        = atmelavr
+board           = megaatmega2560
+upload_protocol = wiring
+monitor_speed   = 115200
+
+build_src_filter =
+    +<*>
+    +<../../../../../core/ktos.c>
+    +<../../../../../bsp/atmega2560/ktos_bsp.c>
+
+build_flags =
+    -Os
+    -Wall
+    -Wextra
+    -I../../../../core
+    -I../../../../bsp/atmega2560

--- a/examples/Arduino/Mega/button_control/src/main.c
+++ b/examples/Arduino/Mega/button_control/src/main.c
@@ -1,0 +1,176 @@
+/*
+ * KTOS — Arduino Mega 2560 button control example (bare-metal)
+ *
+ * Two cooperating KTOS tasks:
+ *
+ *   button_task ('B') -- wakes every 5 ms, samples D2 (PE4) with the
+ *                        internal pull-up, applies a 30 ms debounce,
+ *                        and on every confirmed edge publishes:
+ *                            ktos_SendMsg(ui_task, MSG_BUTTON_EVENT,
+ *                                         pressed ? 1 : 0, 0);
+ *
+ *   ui_task     ('I') -- sleeps with MSG_WAIT until a button event
+ *                        arrives, then prints "Button pressed" or
+ *                        "Button released" over USART0.
+ *
+ * Note: D2 on the Mega 2560 is PE4, not PD2 as on the Uno/Nano.
+ * Connect a button between D2 and GND; internal pull-up drives D2 high
+ * when the button is open.
+ */
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "../../../../../core/ktos.h"
+
+/* =========================================================================
+ * USART0 — 115200 8N1 (U2X0=1, UBRR0=16)
+ * ========================================================================= */
+
+static void uart_init(void)
+{
+    UBRR0H = 0;
+    UBRR0L = 16;
+    UCSR0A = (1 << U2X0);
+    UCSR0B = (1 << TXEN0) | (1 << RXEN0);
+    UCSR0C = (1 << UCSZ01) | (1 << UCSZ00);
+}
+
+static void uart_putc(char c)
+{
+    while (!(UCSR0A & (1 << UDRE0))) { }
+    UDR0 = (uint8_t)c;
+}
+
+static void uart_puts(const char *s)
+{
+    while (*s) { uart_putc(*s++); }
+}
+
+/* =========================================================================
+ * Button on D2 = PE4 (Mega 2560)
+ * ========================================================================= */
+
+#define BTN_DDR   DDRE
+#define BTN_PORT  PORTE
+#define BTN_PIN   PINE
+#define BTN_BIT   PINE4
+
+static inline void btn_init(void)
+{
+    BTN_DDR  &= (uint8_t)~(1 << BTN_BIT);   /* input */
+    BTN_PORT |=  (1 << BTN_BIT);             /* pull-up enabled */
+}
+
+static inline bool btn_pressed(void)
+{
+    return !(BTN_PIN & (1 << BTN_BIT));      /* active-low */
+}
+
+/* =========================================================================
+ * KTOS platform callbacks
+ * ========================================================================= */
+
+__attribute__((noreturn))
+void ktos_Emergency(const char *msg)
+{
+    uart_puts("\r\n[KTOS FATAL] ");
+    uart_puts(msg);
+    uart_puts("\r\n");
+    while (1) { }
+}
+
+void ktos_DebugPrintf(const char *fmt, ...) { (void)fmt; }
+void ktos_InitSys(void) { }
+
+ISR(TIMER1_COMPA_vect) { ktos_timer_irq_handler(); }
+
+/* =========================================================================
+ * Message types
+ * ========================================================================= */
+
+#define MSG_BUTTON_EVENT ((WORD)(KTOS_MSG_TYPE_SYSTEM_START + 1))
+#define BTN_POLL_MS      5U
+#define DEBOUNCE_MS      30U
+#define DEBOUNCE_TICKS   (DEBOUNCE_MS / BTN_POLL_MS)
+
+static struct ktos_TASK *g_ui_task = NULL;
+
+/* =========================================================================
+ * Button task — polls and debounces
+ * ========================================================================= */
+
+static WORD button_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam;
+    (void)lParam;
+
+    static bool    last_stable  = false;
+    static bool    candidate    = false;
+    static uint8_t stable_ticks = 0;
+
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        btn_init();
+        last_stable = btn_pressed();
+        return BTN_POLL_MS;
+    }
+
+    bool raw = btn_pressed();
+
+    if (raw == candidate) {
+        if (stable_ticks < DEBOUNCE_TICKS) {
+            stable_ticks++;
+        }
+    } else {
+        candidate    = raw;
+        stable_ticks = 0;
+    }
+
+    if (stable_ticks >= DEBOUNCE_TICKS && candidate != last_stable) {
+        last_stable = candidate;
+        ktos_SendMsg(g_ui_task, MSG_BUTTON_EVENT, last_stable ? 1u : 0u, 0);
+    }
+
+    return BTN_POLL_MS;
+}
+
+/* =========================================================================
+ * UI task — prints events
+ * ========================================================================= */
+
+static WORD ui_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)lParam;
+
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        uart_puts("=============================\r\n");
+        uart_puts("  KTOS Button Control\r\n");
+        uart_puts("  Arduino Mega 2560\r\n");
+        uart_puts("=============================\r\n");
+        uart_puts("Connect button: D2 (PE4) to GND\r\n");
+        return MSG_WAIT;
+    }
+
+    if (MsgType == MSG_BUTTON_EVENT) {
+        uart_puts(sParam ? "Button pressed\r\n" : "Button released\r\n");
+    }
+
+    return MSG_WAIT;
+}
+
+/* =========================================================================
+ * Entry point
+ * ========================================================================= */
+
+int main(void)
+{
+    uart_init();
+
+    g_ui_task = ktos_InitTask(ui_task,     64, 4, 'I');
+    ktos_InitTask(button_task, 64, 4, 'B');
+
+    ktos_RunOS();
+    return 0;
+}

--- a/examples/Arduino/Mega/i2c/platformio.ini
+++ b/examples/Arduino/Mega/i2c/platformio.ini
@@ -1,0 +1,22 @@
+; KTOS — Arduino Mega 2560 I2C scanner example (bare-metal, no Arduino framework)
+;
+; Single KTOS task scans I2C addresses 0x01..0x7E every 5 seconds
+; using the ATmega2560 TWI peripheral (SDA=D20, SCL=D21).
+
+[env:megaatmega2560]
+platform        = atmelavr
+board           = megaatmega2560
+upload_protocol = wiring
+monitor_speed   = 115200
+
+build_src_filter =
+    +<*>
+    +<../../../../../core/ktos.c>
+    +<../../../../../bsp/atmega2560/ktos_bsp.c>
+
+build_flags =
+    -Os
+    -Wall
+    -Wextra
+    -I../../../../core
+    -I../../../../bsp/atmega2560

--- a/examples/Arduino/Mega/i2c/src/main.c
+++ b/examples/Arduino/Mega/i2c/src/main.c
@@ -1,0 +1,155 @@
+/*
+ * KTOS — Arduino Mega 2560 I2C scanner example (bare-metal)
+ *
+ * One KTOS task scans the I2C bus from 0x01..0x7E:
+ *
+ *   KTOS_MSG_TYPE_INIT   -> banner + TWI init, immediate first scan
+ *   KTOS_MSG_TYPE_TIMER  -> rescan every 5000 ms
+ *
+ * SDA = D20 (PD1), SCL = D21 (PD0) on the Mega 2560.
+ * TWI runs at 100 kHz from a 16 MHz F_CPU.
+ * No Arduino framework, no Wire library — just registers.
+ */
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "../../../../../core/ktos.h"
+
+/* =========================================================================
+ * USART0 — 115200 8N1 (U2X0=1, UBRR0=16)
+ * ========================================================================= */
+
+static void uart_init(void)
+{
+    UBRR0H = 0;
+    UBRR0L = 16;
+    UCSR0A = (1 << U2X0);
+    UCSR0B = (1 << TXEN0) | (1 << RXEN0);
+    UCSR0C = (1 << UCSZ01) | (1 << UCSZ00);
+}
+
+static void uart_putc(char c)
+{
+    while (!(UCSR0A & (1 << UDRE0))) { }
+    UDR0 = (uint8_t)c;
+}
+
+static void uart_puts(const char *s)
+{
+    while (*s) { uart_putc(*s++); }
+}
+
+static void uart_puthex8(uint8_t v)
+{
+    const char *hex = "0123456789ABCDEF";
+    uart_putc(hex[v >> 4]);
+    uart_putc(hex[v & 0x0F]);
+}
+
+/* =========================================================================
+ * TWI (I2C) — 100 kHz at 16 MHz
+ * TWBR = ((F_CPU / F_SCL) - 16) / (2 * prescaler) = (16000000/100000 - 16) / 2 = 72
+ * ========================================================================= */
+
+static void twi_init(void)
+{
+    TWSR = 0x00;    /* prescaler = 1 */
+    TWBR = 72;      /* 100 kHz at 16 MHz */
+    TWCR = (1 << TWEN);
+}
+
+static bool twi_start(uint8_t addr_rw)
+{
+    TWCR = (1 << TWINT) | (1 << TWSTA) | (1 << TWEN);
+    while (!(TWCR & (1 << TWINT))) { }
+    if ((TWSR & 0xF8) != 0x08 && (TWSR & 0xF8) != 0x10) { return false; }
+
+    TWDR = addr_rw;
+    TWCR = (1 << TWINT) | (1 << TWEN);
+    while (!(TWCR & (1 << TWINT))) { }
+
+    uint8_t status = TWSR & 0xF8;
+    return (status == 0x18 || status == 0x40);  /* SLA+W ACK or SLA+R ACK */
+}
+
+static void twi_stop(void)
+{
+    TWCR = (1 << TWINT) | (1 << TWSTO) | (1 << TWEN);
+}
+
+/* =========================================================================
+ * KTOS platform callbacks
+ * ========================================================================= */
+
+__attribute__((noreturn))
+void ktos_Emergency(const char *msg)
+{
+    uart_puts("\r\n[KTOS FATAL] ");
+    uart_puts(msg);
+    uart_puts("\r\n");
+    while (1) { }
+}
+
+void ktos_DebugPrintf(const char *fmt, ...) { (void)fmt; }
+void ktos_InitSys(void) { }
+
+ISR(TIMER1_COMPA_vect) { ktos_timer_irq_handler(); }
+
+/* =========================================================================
+ * I2C scan task
+ * ========================================================================= */
+
+static void do_scan(void)
+{
+    uint8_t found = 0;
+    uart_puts("Scanning I2C bus...\r\n");
+
+    for (uint8_t addr = 0x01; addr <= 0x7E; addr++) {
+        if (twi_start((uint8_t)(addr << 1))) {
+            uart_puts("  Found: 0x");
+            uart_puthex8(addr);
+            uart_puts("\r\n");
+            found++;
+        }
+        twi_stop();
+    }
+
+    if (found == 0) {
+        uart_puts("  No devices found.\r\n");
+    }
+}
+
+static WORD i2c_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam;
+    (void)lParam;
+
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        twi_init();
+        uart_puts("=============================\r\n");
+        uart_puts("  KTOS I2C Scanner\r\n");
+        uart_puts("  Arduino Mega 2560\r\n");
+        uart_puts("  SDA=D20, SCL=D21\r\n");
+        uart_puts("=============================\r\n");
+        do_scan();
+        return 5000;
+    }
+
+    do_scan();
+    return 5000;
+}
+
+/* =========================================================================
+ * Entry point
+ * ========================================================================= */
+
+int main(void)
+{
+    uart_init();
+    ktos_InitTask(i2c_task, 128, 4, 'I');
+    ktos_RunOS();
+    return 0;
+}

--- a/examples/Arduino/Mega/led_control/platformio.ini
+++ b/examples/Arduino/Mega/led_control/platformio.ini
@@ -1,0 +1,24 @@
+; KTOS — Arduino Mega 2560 LED control example (bare-metal, no Arduino framework)
+;
+; Two KTOS tasks:
+;   uart_task -> reads USART0, parses ON/OFF/BLINK,
+;                ktos_SendMsg(led_task, MSG_SET_MODE, mode, 0)
+;   led_task  -> drives D13 (PB7), periodic blink or solid on/off
+
+[env:megaatmega2560]
+platform        = atmelavr
+board           = megaatmega2560
+upload_protocol = wiring
+monitor_speed   = 115200
+
+build_src_filter =
+    +<*>
+    +<../../../../../core/ktos.c>
+    +<../../../../../bsp/atmega2560/ktos_bsp.c>
+
+build_flags =
+    -Os
+    -Wall
+    -Wextra
+    -I../../../../core
+    -I../../../../bsp/atmega2560

--- a/examples/Arduino/Mega/led_control/src/main.c
+++ b/examples/Arduino/Mega/led_control/src/main.c
@@ -1,0 +1,216 @@
+/*
+ * KTOS — Arduino Mega 2560 LED control example (bare-metal)
+ *
+ * Two cooperating KTOS tasks:
+ *
+ *   uart_task  ('U') -- polls USART0 RX every 20 ms, builds a line,
+ *                       parses ON/OFF/BLINK, posts MSG_SET_MODE to led_task.
+ *
+ *   led_task   ('L') -- owns D13 (PB7 on Mega 2560).  On MSG_SET_MODE
+ *                       it switches between OFF / ON / BLINK.
+ *
+ * No Arduino framework — direct register access to USART0 and PORTB.
+ *
+ * Note: D13 on the Mega 2560 is PB7, unlike the Uno/Nano where it is PB5.
+ */
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "../../../../../core/ktos.h"
+
+/* =========================================================================
+ * USART0 — 115200 8N1 (U2X0=1, UBRR0=16)
+ * ========================================================================= */
+
+static void uart_init(void)
+{
+    UBRR0H = 0;
+    UBRR0L = 16;
+    UCSR0A = (1 << U2X0);
+    UCSR0B = (1 << TXEN0) | (1 << RXEN0);
+    UCSR0C = (1 << UCSZ01) | (1 << UCSZ00);
+}
+
+static void uart_putc(char c)
+{
+    while (!(UCSR0A & (1 << UDRE0))) { }
+    UDR0 = (uint8_t)c;
+}
+
+static void uart_puts(const char *s)
+{
+    while (*s) { uart_putc(*s++); }
+}
+
+static int16_t uart_get_byte(void)
+{
+    if (!(UCSR0A & (1 << RXC0))) { return -1; }
+    return (int16_t)UDR0;
+}
+
+/* =========================================================================
+ * LED on D13 = PB7 (Mega 2560 — differs from Uno/Nano which use PB5)
+ * ========================================================================= */
+
+#define LED_DDR   DDRB
+#define LED_PORT  PORTB
+#define LED_BIT   PORTB7
+
+static inline void led_init(void)   { LED_DDR  |=  (1 << LED_BIT); }
+static inline void led_on(void)     { LED_PORT |=  (1 << LED_BIT); }
+static inline void led_off(void)    { LED_PORT &= (uint8_t)~(1 << LED_BIT); }
+static inline void led_toggle(void) { LED_PORT ^=  (1 << LED_BIT); }
+
+/* =========================================================================
+ * KTOS platform callbacks
+ * ========================================================================= */
+
+__attribute__((noreturn))
+void ktos_Emergency(const char *msg)
+{
+    uart_puts("\r\n[KTOS FATAL] ");
+    uart_puts(msg);
+    uart_puts("\r\n");
+    while (1) { }
+}
+
+void ktos_DebugPrintf(const char *fmt, ...) { (void)fmt; }
+void ktos_InitSys(void) { }
+
+ISR(TIMER1_COMPA_vect) { ktos_timer_irq_handler(); }
+
+/* =========================================================================
+ * Message types and mode constants
+ * ========================================================================= */
+
+#define MSG_SET_MODE    ((WORD)(KTOS_MSG_TYPE_SYSTEM_START + 1))
+#define MODE_OFF        0
+#define MODE_ON         1
+#define MODE_BLINK      2
+#define BLINK_PERIOD_MS 500U
+#define UART_POLL_MS    20U
+#define CMD_BUF_SIZE    16U
+
+static struct ktos_TASK *g_led_task = NULL;
+
+/* =========================================================================
+ * LED task
+ * ========================================================================= */
+
+static uint8_t g_led_mode  = MODE_BLINK;
+static bool    g_led_level = false;
+
+static WORD led_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)lParam;
+
+    switch (MsgType) {
+        case KTOS_MSG_TYPE_INIT:
+            led_init();
+            led_off();
+            uart_puts("LED BLINK\r\n");
+            g_led_mode = MODE_BLINK;
+            return BLINK_PERIOD_MS;
+
+        case KTOS_MSG_TYPE_TIMER:
+            if (g_led_mode == MODE_BLINK) {
+                g_led_level = !g_led_level;
+                if (g_led_level) { led_on(); } else { led_off(); }
+                return BLINK_PERIOD_MS;
+            }
+            return MSG_WAIT;
+
+        case MSG_SET_MODE:
+            g_led_mode = (uint8_t)sParam;
+            switch (g_led_mode) {
+                case MODE_ON:
+                    led_on();
+                    uart_puts("LED ON\r\n");
+                    return MSG_WAIT;
+                case MODE_OFF:
+                    led_off();
+                    uart_puts("LED OFF\r\n");
+                    return MSG_WAIT;
+                default:
+                    g_led_mode = MODE_BLINK;
+                    uart_puts("LED BLINK\r\n");
+                    return BLINK_PERIOD_MS;
+            }
+    }
+
+    return MSG_WAIT;
+}
+
+/* =========================================================================
+ * UART task
+ * ========================================================================= */
+
+static char    g_cmd_buf[CMD_BUF_SIZE];
+static uint8_t g_cmd_len = 0;
+
+static void dispatch_line(const char *line)
+{
+    if (strcmp(line, "ON") == 0) {
+        ktos_SendMsg(g_led_task, MSG_SET_MODE, MODE_ON, 0);
+    } else if (strcmp(line, "OFF") == 0) {
+        ktos_SendMsg(g_led_task, MSG_SET_MODE, MODE_OFF, 0);
+    } else if (strcmp(line, "BLINK") == 0) {
+        ktos_SendMsg(g_led_task, MSG_SET_MODE, MODE_BLINK, 0);
+    } else if (line[0] != '\0') {
+        uart_puts("Unknown command. Try ON, OFF, BLINK.\r\n");
+    }
+}
+
+static WORD uart_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam;
+    (void)lParam;
+
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        uart_puts("=============================\r\n");
+        uart_puts("  KTOS LED Control Example\r\n");
+        uart_puts("  Arduino Mega 2560\r\n");
+        uart_puts("=============================\r\n");
+        uart_puts("Commands: ON, OFF, BLINK\r\n");
+        return UART_POLL_MS;
+    }
+
+    int16_t b;
+    while ((b = uart_get_byte()) >= 0) {
+        char c = (char)b;
+        if (c == '\r' || c == '\n') {
+            if (g_cmd_len > 0) {
+                g_cmd_buf[g_cmd_len] = '\0';
+                dispatch_line(g_cmd_buf);
+                g_cmd_len = 0;
+            }
+            continue;
+        }
+        const char upper = (c >= 'a' && c <= 'z') ? (char)(c - 32) : c;
+        if (g_cmd_len < (CMD_BUF_SIZE - 1)) {
+            g_cmd_buf[g_cmd_len++] = upper;
+        }
+    }
+
+    return UART_POLL_MS;
+}
+
+/* =========================================================================
+ * Entry point
+ * ========================================================================= */
+
+int main(void)
+{
+    uart_init();
+    led_init();
+
+    g_led_task = ktos_InitTask(led_task,  64, 4, 'L');
+    ktos_InitTask(uart_task, 80, 4, 'U');
+
+    ktos_RunOS();
+    return 0;
+}

--- a/examples/Arduino/Mega/spi/platformio.ini
+++ b/examples/Arduino/Mega/spi/platformio.ini
@@ -1,0 +1,23 @@
+; KTOS — Arduino Mega 2560 SPI loopback example (bare-metal, no Arduino framework)
+;
+; Single KTOS task drives hardware SPI in master mode and runs a
+; loopback self-test once per second.
+; Connect MOSI (D51 / PB2) to MISO (D50 / PB3) with a jumper wire.
+
+[env:megaatmega2560]
+platform        = atmelavr
+board           = megaatmega2560
+upload_protocol = wiring
+monitor_speed   = 115200
+
+build_src_filter =
+    +<*>
+    +<../../../../../core/ktos.c>
+    +<../../../../../bsp/atmega2560/ktos_bsp.c>
+
+build_flags =
+    -Os
+    -Wall
+    -Wextra
+    -I../../../../core
+    -I../../../../bsp/atmega2560

--- a/examples/Arduino/Mega/spi/src/main.c
+++ b/examples/Arduino/Mega/spi/src/main.c
@@ -1,0 +1,178 @@
+/*
+ * KTOS — Arduino Mega 2560 SPI loopback example (bare-metal)
+ *
+ * A single KTOS task drives the ATmega2560's hardware SPI peripheral
+ * in master mode and runs a loopback self-test once per second.
+ *
+ *   KTOS_MSG_TYPE_INIT   -> banner, configure SPI, do one immediate test
+ *   KTOS_MSG_TYPE_TIMER  -> repeat the test, sleep 1000 ms
+ *
+ * Mega 2560 SPI pins (hardware, Port B):
+ *   MOSI = D51 / PB2
+ *   MISO = D50 / PB3
+ *   SCK  = D52 / PB1
+ *   SS   = D53 / PB0  (driven low by software before each transfer)
+ *
+ * Connect MOSI (D51) to MISO (D50) with a single jumper wire.
+ * Unlike the Nano/Uno, D13 (PB7) is not the SCK pin on the Mega, so
+ * the on-board LED does not flicker during transfers.
+ *
+ * No Arduino framework, no SPI.h — direct register access only.
+ */
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "../../../../../core/ktos.h"
+
+/* =========================================================================
+ * USART0 — 115200 8N1 (U2X0=1, UBRR0=16)
+ * ========================================================================= */
+
+static void uart_init(void)
+{
+    UBRR0H = 0;
+    UBRR0L = 16;
+    UCSR0A = (1 << U2X0);
+    UCSR0B = (1 << TXEN0) | (1 << RXEN0);
+    UCSR0C = (1 << UCSZ01) | (1 << UCSZ00);
+}
+
+static void uart_putc(char c)
+{
+    while (!(UCSR0A & (1 << UDRE0))) { }
+    UDR0 = (uint8_t)c;
+}
+
+static void uart_puts(const char *s)
+{
+    while (*s) { uart_putc(*s++); }
+}
+
+static void uart_puthex8(uint8_t v)
+{
+    const char *hex = "0123456789ABCDEF";
+    uart_putc(hex[v >> 4]);
+    uart_putc(hex[v & 0x0F]);
+}
+
+/* =========================================================================
+ * SPI master — Mega 2560 pin mapping
+ *   SS   = PB0 = D53
+ *   SCK  = PB1 = D52
+ *   MOSI = PB2 = D51
+ *   MISO = PB3 = D50  (input)
+ * ========================================================================= */
+
+#define SPI_SS_BIT    PB0
+#define SPI_SCK_BIT   PB1
+#define SPI_MOSI_BIT  PB2
+#define SPI_MISO_BIT  PB3
+
+static void spi_init(void)
+{
+    /* MOSI, SCK, SS as outputs; MISO as input */
+    DDRB |= (1 << SPI_SS_BIT) | (1 << SPI_SCK_BIT) | (1 << SPI_MOSI_BIT);
+    DDRB &= (uint8_t)~(1 << SPI_MISO_BIT);
+
+    /* SS idle high */
+    PORTB |= (1 << SPI_SS_BIT);
+
+    /* Enable SPI, master mode, clock = F_CPU / 16 = 1 MHz */
+    SPCR = (1 << SPE) | (1 << MSTR) | (1 << SPR0);
+}
+
+static uint8_t spi_transfer(uint8_t data)
+{
+    SPDR = data;
+    while (!(SPSR & (1 << SPIF))) { }
+    return SPDR;
+}
+
+/* =========================================================================
+ * KTOS platform callbacks
+ * ========================================================================= */
+
+__attribute__((noreturn))
+void ktos_Emergency(const char *msg)
+{
+    uart_puts("\r\n[KTOS FATAL] ");
+    uart_puts(msg);
+    uart_puts("\r\n");
+    while (1) { }
+}
+
+void ktos_DebugPrintf(const char *fmt, ...) { (void)fmt; }
+void ktos_InitSys(void) { }
+
+ISR(TIMER1_COMPA_vect) { ktos_timer_irq_handler(); }
+
+/* =========================================================================
+ * Test pattern
+ * ========================================================================= */
+
+static const uint8_t k_pattern[] = { 0xA5, 0x5A, 0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0xFF };
+#define PATTERN_LEN ((uint8_t)(sizeof(k_pattern) / sizeof(k_pattern[0])))
+
+static void run_loopback(void)
+{
+    uint8_t errors = 0;
+
+    PORTB &= (uint8_t)~(1 << SPI_SS_BIT);   /* assert SS */
+
+    for (uint8_t i = 0; i < PATTERN_LEN; i++) {
+        uint8_t rx = spi_transfer(k_pattern[i]);
+        if (rx != k_pattern[i]) { errors++; }
+    }
+
+    PORTB |= (1 << SPI_SS_BIT);             /* deassert SS */
+
+    if (errors == 0) {
+        uart_puts("Loopback OK  (");
+        uart_puthex8(PATTERN_LEN);
+        uart_puts(" bytes)\r\n");
+    } else {
+        uart_puts("Loopback FAIL  errors=");
+        uart_puthex8(errors);
+        uart_puts("  (D51 -> D50 jumper connected?)\r\n");
+    }
+}
+
+/* =========================================================================
+ * SPI task
+ * ========================================================================= */
+
+static WORD spi_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam;
+    (void)lParam;
+
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        spi_init();
+        uart_puts("=============================\r\n");
+        uart_puts("  KTOS SPI Loopback\r\n");
+        uart_puts("  Arduino Mega 2560\r\n");
+        uart_puts("  MOSI=D51, MISO=D50, SCK=D52\r\n");
+        uart_puts("  Connect D51 to D50\r\n");
+        uart_puts("=============================\r\n");
+        run_loopback();
+        return 1000;
+    }
+
+    run_loopback();
+    return 1000;
+}
+
+/* =========================================================================
+ * Entry point
+ * ========================================================================= */
+
+int main(void)
+{
+    uart_init();
+    ktos_InitTask(spi_task, 96, 4, 'S');
+    ktos_RunOS();
+    return 0;
+}

--- a/examples/Arduino/Mega/uart/platformio.ini
+++ b/examples/Arduino/Mega/uart/platformio.ini
@@ -1,0 +1,24 @@
+; KTOS — Arduino Mega 2560 UART example (bare-metal, no Arduino framework)
+;
+; Two KTOS tasks:
+;   rx_task  -> drains USART0 into a fixed buffer, posts a complete
+;               line to cmd_task with MSG_LINE_READY.
+;   cmd_task -> parses PING / INFO / HELP and prints the response.
+
+[env:megaatmega2560]
+platform        = atmelavr
+board           = megaatmega2560
+upload_protocol = wiring
+monitor_speed   = 115200
+
+build_src_filter =
+    +<*>
+    +<../../../../../core/ktos.c>
+    +<../../../../../bsp/atmega2560/ktos_bsp.c>
+
+build_flags =
+    -Os
+    -Wall
+    -Wextra
+    -I../../../../core
+    -I../../../../bsp/atmega2560

--- a/examples/Arduino/Mega/uart/src/main.c
+++ b/examples/Arduino/Mega/uart/src/main.c
@@ -1,0 +1,208 @@
+/*
+ * KTOS — Arduino Mega 2560 UART example (bare-metal)
+ *
+ * Two cooperating KTOS tasks demonstrate the canonical "producer /
+ * consumer" pattern with a single hardware UART.  No Arduino runtime
+ * is involved — USART0 is driven directly through its registers.
+ *
+ *   rx_task  ('R') -- wakes every 10 ms, drains USART0's RX FIFO into
+ *                     a fixed 64-byte buffer.  Echoes every received
+ *                     byte (CRLF translated for terminal hygiene).
+ *                     When a newline is seen, the assembled line is
+ *                     copied into a shared buffer and:
+ *                         ktos_SendMsg(cmd_task, MSG_LINE_READY, len, 0);
+ *
+ *   cmd_task ('C') -- sleeps with MSG_WAIT.  On MSG_LINE_READY it
+ *                     parses the line (PING / INFO / HELP) and writes
+ *                     the response.
+ *
+ * USART0 TX = D1 (PE1), RX = D0 (PE0).  Connect via the on-board
+ * USB-to-serial chip; open a monitor at 115200 8N1.
+ */
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "../../../../../core/ktos.h"
+
+/* =========================================================================
+ * USART0 — 115200 8N1 (U2X0=1, UBRR0=16 → 117647 baud, 2.1% error)
+ * ========================================================================= */
+
+static void uart_init(void)
+{
+    UBRR0H = 0;
+    UBRR0L = 16;
+    UCSR0A = (1 << U2X0);
+    UCSR0B = (1 << TXEN0) | (1 << RXEN0);
+    UCSR0C = (1 << UCSZ01) | (1 << UCSZ00);
+}
+
+static void uart_putc(char c)
+{
+    while (!(UCSR0A & (1 << UDRE0))) { }
+    UDR0 = (uint8_t)c;
+}
+
+static void uart_puts(const char *s)
+{
+    while (*s) { uart_putc(*s++); }
+}
+
+static int16_t uart_get_byte(void)
+{
+    if (!(UCSR0A & (1 << RXC0))) { return -1; }
+    return (int16_t)UDR0;
+}
+
+/* =========================================================================
+ * KTOS platform callbacks
+ * ========================================================================= */
+
+__attribute__((noreturn))
+void ktos_Emergency(const char *msg)
+{
+    uart_puts("\r\n[KTOS FATAL] ");
+    uart_puts(msg);
+    uart_puts("\r\n");
+    while (1) { }
+}
+
+void ktos_DebugPrintf(const char *fmt, ...) { (void)fmt; }
+void ktos_InitSys(void) { }
+
+/* =========================================================================
+ * KTOS 1 ms tick — Timer1 CTC (configured by atmega2560 BSP)
+ * ========================================================================= */
+
+extern void ktos_timer_irq_handler(void);
+
+ISR(TIMER1_COMPA_vect)
+{
+    ktos_timer_irq_handler();
+}
+
+/* =========================================================================
+ * Application message types
+ * ========================================================================= */
+
+#define MSG_LINE_READY  ((WORD)(KTOS_MSG_TYPE_SYSTEM_START + 1))
+
+#define LINE_BUF_SIZE   64U
+#define RX_POLL_MS      10U
+
+static char    g_line_buf[LINE_BUF_SIZE];
+static uint8_t g_assembling_len = 0;
+
+static struct ktos_TASK *g_cmd_task = NULL;
+
+/* =========================================================================
+ * Command task
+ * ========================================================================= */
+
+static void print_info(void)
+{
+    uart_puts("Board   : Arduino Mega 2560\r\n");
+    uart_puts("Clock   : 16 MHz\r\n");
+    uart_puts("SRAM    : 8 KB\r\n");
+    uart_puts("Flash   : 256 KB\r\n");
+    uart_puts("Baud    : 115200, 8N1\r\n");
+    uart_puts("OS      : KTOS\r\n");
+}
+
+static void print_help(void)
+{
+    uart_puts("Commands:\r\n");
+    uart_puts("  PING  - reply with PONG\r\n");
+    uart_puts("  INFO  - show board info\r\n");
+    uart_puts("  HELP  - this list\r\n");
+}
+
+static WORD cmd_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam;
+    (void)lParam;
+
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        uart_puts("=============================\r\n");
+        uart_puts("  KTOS UART Example\r\n");
+        uart_puts("  Arduino Mega 2560\r\n");
+        uart_puts("=============================\r\n");
+        uart_puts("Type HELP for commands.\r\n");
+        return MSG_WAIT;
+    }
+
+    if (MsgType != MSG_LINE_READY) { return MSG_WAIT; }
+
+    if (strcmp(g_line_buf, "PING") == 0) {
+        uart_puts("PONG\r\n");
+    } else if (strcmp(g_line_buf, "INFO") == 0) {
+        print_info();
+    } else if (strcmp(g_line_buf, "HELP") == 0) {
+        print_help();
+    } else if (g_line_buf[0] != '\0') {
+        uart_puts("Unknown: ");
+        uart_puts(g_line_buf);
+        uart_puts("\r\n");
+        uart_puts("Type HELP for commands.\r\n");
+    }
+
+    return MSG_WAIT;
+}
+
+/* =========================================================================
+ * RX task
+ * ========================================================================= */
+
+static WORD rx_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam;
+    (void)lParam;
+
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        g_assembling_len = 0;
+        return RX_POLL_MS;
+    }
+
+    int16_t b;
+    while ((b = uart_get_byte()) >= 0) {
+        char c = (char)b;
+
+        uart_putc(c);
+        if (c == '\r') { uart_putc('\n'); }
+
+        if (c == '\r' || c == '\n') {
+            if (g_assembling_len > 0) {
+                g_line_buf[g_assembling_len] = '\0';
+                ktos_SendMsg(g_cmd_task, MSG_LINE_READY,
+                             (WORD)g_assembling_len, 0);
+                g_assembling_len = 0;
+            }
+            continue;
+        }
+
+        const char upper = (c >= 'a' && c <= 'z') ? (char)(c - 32) : c;
+        if (g_assembling_len < (LINE_BUF_SIZE - 1)) {
+            g_line_buf[g_assembling_len++] = upper;
+        }
+    }
+
+    return RX_POLL_MS;
+}
+
+/* =========================================================================
+ * Entry point
+ * ========================================================================= */
+
+int main(void)
+{
+    uart_init();
+
+    g_cmd_task = ktos_InitTask(cmd_task, 80, 4, 'C');
+    ktos_InitTask(rx_task, 64, 2, 'R');
+
+    ktos_RunOS();
+    return 0;
+}


### PR DESCRIPTION
Six examples (uart, led_control, button_control, adc, i2c, spi) for the ATmega2560, matching the Nano example set. Key Mega differences handled: D13=PB7, D2=PE4, SPI on PB0-PB3 (D53/52/51/50), 3-byte PC in BSP, upload_protocol=wiring, TWI SDA=D20/SCL=D21.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Tested on hardware platform: <!-- specify which MCU/board -->
- [ ] Unit tests added/updated
- [ ] All existing tests pass
- [ ] Code compiles without warnings

**Test Configuration**:
* MCU/Platform:
* Compiler version:
* Toolchain:

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the pull request here -->

## Related Issues
<!-- Link related issues below. Use "Closes #XX" if this PR closes an issue -->
