### PR TITLE
fix: use uintptr_t casts to suppress comparePointers in startup.c

### DIFF
--- a/bsp/samd21g18/startup.c
+++ b/bsp/samd21g18/startup.c
@@ -190,10 +190,10 @@ void Reset_Handler(void)
 
     /* Copy .data from flash to RAM */
     const uint32_t *src = &_sidata;
-    for (uint32_t *dst = &_sdata; dst < &_edata; ) { *dst++ = *src++; }
+    for (uint32_t *dst = &_sdata; (uintptr_t)dst < (uintptr_t)&_edata; ) { *dst++ = *src++; }
 
     /* Zero .bss */
-    for (uint32_t *p = &_sbss; p < &_ebss; ) { *p++ = 0; }
+    for (uint32_t *p = &_sbss; (uintptr_t)p < (uintptr_t)&_ebss; ) { *p++ = 0; }
 
     main();
     while (1) {}


### PR DESCRIPTION
cppcheck treats separately-declared extern linker symbols as distinct scalar objects, making pointer comparison between them an error. Cast both sides to uintptr_t so the comparison is between integers, which is valid C and cppcheck-clean.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Tested on hardware platform: <!-- specify which MCU/board -->
- [ ] Unit tests added/updated
- [ ] All existing tests pass
- [ ] Code compiles without warnings

**Test Configuration**:
* MCU/Platform:
* Compiler version:
* Toolchain:

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the pull request here -->

## Related Issues
<!-- Link related issues below. Use "Closes #XX" if this PR closes an issue -->
