### PR TITLE
feat: add STM32F030 Nucleo-F030R8 bare-metal KTOS examples - Add bsp/…

### DIFF
--- a/bsp/stm32f030/startup.c
+++ b/bsp/stm32f030/startup.c
@@ -1,0 +1,172 @@
+/*
+ * KTOS — Tiny Cooperative Task Switcher
+ * Copyright (C) 2004-2025 Khalid Hamdou / BAAMIIS LIMITED
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+/**
+ * @file startup.c
+ * @brief STM32F030R8 (Nucleo) bare-metal startup
+ *
+ * Provides:
+ *   - Vector table (.vectors at 0x08000000)
+ *   - Reset_Handler: 48 MHz PLL clock init, .data copy, .bss zero, main()
+ *   - Default_Handler: infinite loop for unhandled exceptions
+ *
+ * Clock chain: HSI 8 MHz → HSI/2 (4 MHz) → PLL ×12 → SYSCLK 48 MHz
+ *              AHB = 48 MHz, APB = 48 MHz
+ *
+ * Every main.c must define:
+ *   void SysTick_Handler(void) { ktos_timer_irq_handler(); }
+ */
+
+#include <stdint.h>
+
+/* Linker script symbols */
+extern uint32_t _sidata;
+extern uint32_t _sdata;
+extern uint32_t _edata;
+extern uint32_t _sbss;
+extern uint32_t _ebss;
+extern uint32_t _estack;
+extern int main(void);
+
+/* =========================================================================
+ * RCC and FLASH registers used during clock init
+ * ========================================================================= */
+#define FLASH_ACR  (*(volatile uint32_t *)0x40022000UL)
+#define RCC_CR     (*(volatile uint32_t *)0x40021000UL)
+#define RCC_CFGR   (*(volatile uint32_t *)0x40021004UL)
+
+static void clock_init_48MHz(void)
+{
+    /* 1 NVM wait state required for 24–48 MHz; enable prefetch */
+    FLASH_ACR = (1u << 4) | 1u;   /* PRFTBE | LATENCY=1 */
+
+    /* PLL: source = HSI/2 (PLLSRC=0, default), PLLMUL = ×12 (bits[21:18]=1010) */
+    RCC_CFGR = (10u << 18);        /* PLLMUL = ×12 → 4 MHz × 12 = 48 MHz */
+
+    /* Enable PLL, wait ready */
+    RCC_CR |= (1u << 24);              /* PLLON  */
+    while (!(RCC_CR & (1u << 25))) {}  /* PLLRDY */
+
+    /* Switch system clock to PLL, wait for switch */
+    RCC_CFGR |= 2u;                                    /* SW = PLL */
+    while ((RCC_CFGR & (3u << 2)) != (2u << 2)) {}    /* SWS = PLL */
+}
+
+/* =========================================================================
+ * Default handler and weak aliases
+ * STM32F030 peripheral IRQs 0–31 (RM0360 Table 36)
+ * ========================================================================= */
+void Default_Handler(void) { while (1) {} }
+
+void NMI_Handler(void)          __attribute__((weak, alias("Default_Handler")));
+void HardFault_Handler(void)    __attribute__((weak, alias("Default_Handler")));
+void SVC_Handler(void)          __attribute__((weak, alias("Default_Handler")));
+void PendSV_Handler(void)       __attribute__((weak, alias("Default_Handler")));
+void SysTick_Handler(void)      __attribute__((weak, alias("Default_Handler")));
+
+void WWDG_IRQHandler(void)          __attribute__((weak, alias("Default_Handler")));
+void RTC_IRQHandler(void)           __attribute__((weak, alias("Default_Handler")));
+void FLASH_IRQHandler(void)         __attribute__((weak, alias("Default_Handler")));
+void RCC_IRQHandler(void)           __attribute__((weak, alias("Default_Handler")));
+void EXTI0_1_IRQHandler(void)       __attribute__((weak, alias("Default_Handler")));
+void EXTI2_3_IRQHandler(void)       __attribute__((weak, alias("Default_Handler")));
+void EXTI4_15_IRQHandler(void)      __attribute__((weak, alias("Default_Handler")));
+void DMA1_Channel1_IRQHandler(void) __attribute__((weak, alias("Default_Handler")));
+void DMA1_Channel2_3_IRQHandler(void) __attribute__((weak, alias("Default_Handler")));
+void DMA1_Channel4_5_IRQHandler(void) __attribute__((weak, alias("Default_Handler")));
+void ADC1_IRQHandler(void)          __attribute__((weak, alias("Default_Handler")));
+void TIM1_BRK_UP_TRG_COM_IRQHandler(void) __attribute__((weak, alias("Default_Handler")));
+void TIM1_CC_IRQHandler(void)       __attribute__((weak, alias("Default_Handler")));
+void TIM3_IRQHandler(void)          __attribute__((weak, alias("Default_Handler")));
+void TIM6_IRQHandler(void)          __attribute__((weak, alias("Default_Handler")));
+void TIM14_IRQHandler(void)         __attribute__((weak, alias("Default_Handler")));
+void TIM15_IRQHandler(void)         __attribute__((weak, alias("Default_Handler")));
+void TIM16_IRQHandler(void)         __attribute__((weak, alias("Default_Handler")));
+void TIM17_IRQHandler(void)         __attribute__((weak, alias("Default_Handler")));
+void I2C1_IRQHandler(void)          __attribute__((weak, alias("Default_Handler")));
+void I2C2_IRQHandler(void)          __attribute__((weak, alias("Default_Handler")));
+void SPI1_IRQHandler(void)          __attribute__((weak, alias("Default_Handler")));
+void SPI2_IRQHandler(void)          __attribute__((weak, alias("Default_Handler")));
+void USART1_IRQHandler(void)        __attribute__((weak, alias("Default_Handler")));
+void USART2_IRQHandler(void)        __attribute__((weak, alias("Default_Handler")));
+void USART3_4_IRQHandler(void)      __attribute__((weak, alias("Default_Handler")));
+void USB_IRQHandler(void)           __attribute__((weak, alias("Default_Handler")));
+
+/* =========================================================================
+ * Vector table at 0x08000000
+ * ========================================================================= */
+typedef void (*isr_t)(void);
+void Reset_Handler(void);
+
+__attribute__((section(".vectors"), used))
+static const isr_t vector_table[] = {
+    (isr_t)&_estack,           /* Initial SP                     */
+    Reset_Handler,              /* Reset                          */
+    NMI_Handler,
+    HardFault_Handler,
+    0, 0, 0, 0, 0, 0, 0,      /* Reserved (M0 has no M3 faults) */
+    SVC_Handler,
+    0, 0,                      /* Reserved                       */
+    PendSV_Handler,
+    SysTick_Handler,           /* KTOS 1 ms tick                 */
+    /* Peripheral IRQs 0–31 (RM0360 Table 36) */
+    WWDG_IRQHandler,                    /*  0 */
+    RTC_IRQHandler,                     /*  1 */
+    FLASH_IRQHandler,                   /*  2 */
+    RCC_IRQHandler,                     /*  3 */
+    EXTI0_1_IRQHandler,                 /*  4 */
+    EXTI2_3_IRQHandler,                 /*  5 */
+    EXTI4_15_IRQHandler,                /*  6 */
+    0,                                  /*  7 Reserved */
+    DMA1_Channel1_IRQHandler,           /*  8 */
+    DMA1_Channel2_3_IRQHandler,         /*  9 */
+    DMA1_Channel4_5_IRQHandler,         /* 10 */
+    ADC1_IRQHandler,                    /* 11 */
+    TIM1_BRK_UP_TRG_COM_IRQHandler,     /* 12 */
+    TIM1_CC_IRQHandler,                 /* 13 */
+    0,                                  /* 14 Reserved */
+    TIM3_IRQHandler,                    /* 15 */
+    TIM6_IRQHandler,                    /* 16 */
+    0,                                  /* 17 Reserved */
+    TIM14_IRQHandler,                   /* 18 */
+    TIM15_IRQHandler,                   /* 19 */
+    TIM16_IRQHandler,                   /* 20 */
+    TIM17_IRQHandler,                   /* 21 */
+    I2C1_IRQHandler,                    /* 22 */
+    I2C2_IRQHandler,                    /* 23 */
+    SPI1_IRQHandler,                    /* 24 */
+    SPI2_IRQHandler,                    /* 25 */
+    USART1_IRQHandler,                  /* 26 */
+    USART2_IRQHandler,                  /* 27 */
+    USART3_4_IRQHandler,                /* 28 */
+    0,                                  /* 29 Reserved */
+    0,                                  /* 30 Reserved */
+    USB_IRQHandler,                     /* 31 */
+};
+
+/* =========================================================================
+ * Reset handler
+ * ========================================================================= */
+void Reset_Handler(void)
+{
+    clock_init_48MHz();
+
+    /* Copy .data from flash to RAM */
+    const uint32_t *src = &_sidata;
+    for (uint32_t *dst = &_sdata; (uintptr_t)dst < (uintptr_t)&_edata; ) {
+        *dst++ = *src++;
+    }
+
+    /* Zero .bss */
+    for (uint32_t *p = &_sbss; (uintptr_t)p < (uintptr_t)&_ebss; ) {
+        *p++ = 0;
+    }
+
+    main();
+    while (1) {}
+}

--- a/bsp/stm32f030/stm32f030.ld
+++ b/bsp/stm32f030/stm32f030.ld
@@ -1,0 +1,20 @@
+/* Linker script for STM32F030R8 (Nucleo): 64 KB flash, 8 KB RAM */
+MEMORY
+{
+    FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 64K
+    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 8K
+}
+
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+
+SECTIONS
+{
+    .vectors : { KEEP(*(.vectors)) } > FLASH
+    .text    : { *(.text*) *(.rodata*) . = ALIGN(4); } > FLASH
+
+    _sidata = LOADADDR(.data);
+    .data   : { _sdata = .; *(.data*) . = ALIGN(4); _edata = .; } > RAM AT > FLASH
+    .bss (NOLOAD) : { _sbss = .; *(.bss*) *(COMMON) . = ALIGN(4); _ebss = .; } > RAM
+
+    PROVIDE(_end = _ebss);
+}

--- a/examples/stm32f030/README.md
+++ b/examples/stm32f030/README.md
@@ -1,0 +1,103 @@
+### KTOS on STM32F030 — Examples
+
+KTOS bare-metal examples for the **STM32F030R8 Nucleo** (ARM Cortex-M0 @ 48 MHz).
+All peripherals accessed directly through registers — no HAL, no CMSIS.
+
+---
+
+## Examples
+
+| Folder              | Demonstrates                                                              |
+|---------------------|---------------------------------------------------------------------------|
+| [`uart/`](uart/)    | **Two tasks**, RX line assembler → PING/INFO/HELP command dispatcher.    |
+| [`led_control/`](led_control/) | **Two tasks**, `ktos_SendMsg(MSG_SET_MODE)` from UART task to LED task (LD2/PA5). |
+| [`button_control/`](button_control/) | **Two tasks**, 30 ms debouncer on B1 (PC13) → `MSG_BUTTON_EVENT` → LD2 toggle. |
+| [`adc/`](adc/)      | One task, 1 Hz read of PA0 (ADC1 CH0), 12-bit, 3.3 V ref.              |
+| [`i2c/`](i2c/)      | One task, I2C1 scanner (PB6=SCL, PB7=SDA), 100 kHz, scan every 5 s.   |
+| [`spi/`](spi/)      | One task, SPI1 external loopback (PA5/PA6/PA7), 6 MHz. *(PA6–PA7 jumper required.)* |
+
+---
+
+## Board Overview
+
+| Item              | Value                                                        |
+|-------------------|--------------------------------------------------------------|
+| Board             | STM32F030R8 Nucleo-64                                        |
+| MCU               | STM32F030R8T6 (ARM Cortex-M0)                               |
+| Clock             | 48 MHz (HSI 8 MHz → HSI/2 → PLL ×12)                        |
+| Logic level       | **3.3 V**                                                    |
+| Flash             | 64 KB at 0x08000000                                          |
+| SRAM              | 8 KB at 0x20000000                                           |
+| KTOS BSP          | [`bsp/stm32f030/`](../../bsp/stm32f030/)                     |
+| KTOS tick source  | **SysTick**, 1 ms (LOAD = 47999)                             |
+| Programmer        | ST-Link/V2-1 (on-board)                                      |
+| PlatformIO board  | `nucleo_f030r8`                                              |
+
+---
+
+## Key Differences from STM32F103
+
+| Feature       | STM32F103 (F1)                   | STM32F030 (F0)                         |
+|---------------|----------------------------------|----------------------------------------|
+| GPIO base     | 0x4001xxxx                       | **0x4800xxxx**                         |
+| GPIO config   | CRL/CRH (4 bits/pin)             | **MODER/OTYPER/PUPDR/AFR** (2 bits/pin)|
+| GPIO clocks   | RCC_APB2ENR                      | **RCC_AHBENR**                         |
+| USART regs    | SR / DR                          | **ISR / TDR / RDR**                    |
+| ADC regs      | CR1/CR2/SQR3/DR                  | **CR / CFGR1 / CHSELR / DR**           |
+| I2C regs      | CCR / TRISE / CR                 | **TIMINGR / CR2 with AUTOEND**         |
+| Context switch | `push {r4-r11}` direct          | Indirect via R4–R7 for R8–R11          |
+
+---
+
+## Pin Map
+
+| Signal            | Pin   | Config                   | Used by                                    |
+|-------------------|-------|--------------------------|--------------------------------------------|
+| USART2 TX (ST-Link)| PA2  | AF1, MODER=10            | all examples                               |
+| USART2 RX (ST-Link)| PA3  | AF1, MODER=10            | uart                                       |
+| LD2 LED (active high)| PA5| output, MODER=01         | led_control, button_control                |
+| ADC1 CH0          | PA0   | analog, MODER=11          | adc                                        |
+| SPI1 SCK          | PA5   | AF0, MODER=10             | spi *(same pin as LD2 — LED inactive)*     |
+| SPI1 MISO         | PA6   | AF0, MODER=10             | spi                                        |
+| SPI1 MOSI         | PA7   | AF0, MODER=10             | spi                                        |
+| B1 USER button    | PC13  | input pull-up, MODER=00  | button_control                             |
+| I2C1 SCL          | PB6   | AF1, open-drain           | i2c                                        |
+| I2C1 SDA          | PB7   | AF1, open-drain           | i2c                                        |
+
+---
+
+## Build and Flash
+
+```bash
+git clone https://github.com/baamiis/KTOS.git
+cd KTOS/examples/stm32f030/uart   # or any example
+pio run                            # compile
+pio run -t upload                  # flash via on-board ST-Link
+pio device monitor -b 115200       # open ST-Link virtual COM
+```
+
+No external hardware required for `uart`, `led_control`, `button_control` — everything is on the Nucleo board.
+
+---
+
+## Required Hardware
+
+| Item                     | Quantity | Notes                                               |
+|--------------------------|----------|-----------------------------------------------------|
+| Nucleo-F030R8            | 1        | On-board ST-Link, LED, button, USB virtual COM      |
+| Micro-USB cable          | 1        | Connects to the CN1 USB connector                   |
+| Signal source            | 0 or 1   | `adc`: 0–3.3 V to PA0 (CN7 pin 28 / A0)           |
+| I²C breakout             | 0+       | `i2c`: PB6 (SCL) / PB7 (SDA) with 4.7 kΩ pull-ups |
+| Jumper wire              | 0 or 1   | `spi`: bridge PA6 (MISO) ↔ PA7 (MOSI)              |
+
+---
+
+## Troubleshooting
+
+| Symptom                      | Likely cause                              | Fix                                               |
+|------------------------------|-------------------------------------------|---------------------------------------------------|
+| No serial output             | Wrong COM port or baud                    | Use ST-Link virtual COM, 115200 baud              |
+| `spi` FAIL on every byte     | PA6–PA7 jumper missing                    | Bridge PA6 (MISO) to PA7 (MOSI)                  |
+| `i2c` hangs on first scan    | Missing pull-up resistors                 | Add 4.7 kΩ from PB6/PB7 to 3.3 V                |
+| Upload fails "No target"     | USB cable or ST-Link issue                | Replug USB; check CN1 connector (not CN5)         |
+| Tasks run but LED wrong      | PA5 shares SCK and LED                   | Normal: in `spi` example LED stays dark           |

--- a/examples/stm32f030/adc/platformio.ini
+++ b/examples/stm32f030/adc/platformio.ini
@@ -1,0 +1,18 @@
+; KTOS — STM32F030 Nucleo ADC example (bare-metal)
+
+[env:nucleo_f030r8]
+platform             = ststm32
+board                = nucleo_f030r8
+upload_protocol      = stlink
+monitor_speed        = 115200
+board_build.ldscript = ../../../bsp/stm32f030/stm32f030.ld
+build_src_filter =
+    +<*>
+    +<../../../../core/ktos.c>
+    +<../../../../bsp/stm32f030/ktos_bsp.c>
+    +<../../../../bsp/stm32f030/startup.c>
+build_flags =
+    -mcpu=cortex-m0 -mthumb -DF_CPU=48000000UL
+    -Wall -Wextra -Os -ffunction-sections -fdata-sections
+    -Wl,--gc-sections --specs=nosys.specs
+    -I../../../core -I../../../bsp/stm32f030

--- a/examples/stm32f030/adc/src/main.c
+++ b/examples/stm32f030/adc/src/main.c
@@ -1,0 +1,130 @@
+/*
+ * KTOS — STM32F030 Nucleo-F030R8 ADC example (bare-metal)
+ *
+ * Single KTOS task reads ADC1 channel 0 (PA0, CN7 pin 28) every 1 s.
+ * Prints raw 12-bit count and millivolts over USART2.
+ *
+ * Reference: VDDA = 3.3 V → max input 3300 mV.
+ *   mV = raw * 3300 / 4095
+ *
+ * ADC clock: synchronous PCLK/4 = 48/4 = 12 MHz (set via ADC_CFGR2.CKMODE).
+ * USART2: PA2=TX, 115200 8N1 → ST-Link virtual COM.
+ *
+ * STM32F030 ADC uses new-style registers (ADC_CR, ADC_CFGR1/2, ADC_CHSELR).
+ */
+
+#include <stdint.h>
+#include "../../../../core/ktos.h"
+
+#define RCC_AHBENR   (*(volatile uint32_t *)0x40021014UL)
+#define RCC_APB1ENR  (*(volatile uint32_t *)0x4002101CUL)
+#define RCC_APB2ENR  (*(volatile uint32_t *)0x40021018UL)
+
+#define GPIOA_MODER  (*(volatile uint32_t *)0x48000000UL)
+#define GPIOA_AFRL   (*(volatile uint32_t *)0x48000020UL)
+
+#define USART2_CR1   (*(volatile uint32_t *)0x40004400UL)
+#define USART2_BRR   (*(volatile uint32_t *)0x4000440CUL)
+#define USART2_ISR   (*(volatile uint32_t *)0x4000441CUL)
+#define USART2_TDR   (*(volatile uint32_t *)0x40004428UL)
+#define ISR_TXE  (1u << 7)
+
+/* ADC1 new-style registers (STM32F030, base 0x40012400) */
+#define ADC1_ISR     (*(volatile uint32_t *)0x40012400UL)
+#define ADC1_CR      (*(volatile uint32_t *)0x40012408UL)
+#define ADC1_CFGR1   (*(volatile uint32_t *)0x4001240CUL)
+#define ADC1_CFGR2   (*(volatile uint32_t *)0x40012410UL)
+#define ADC1_SMPR    (*(volatile uint32_t *)0x40012414UL)
+#define ADC1_CHSELR  (*(volatile uint32_t *)0x40012428UL)
+#define ADC1_DR      (*(volatile uint32_t *)0x40012440UL)
+
+#define ADC_ADRDY   (1u << 0)
+#define ADC_EOC     (1u << 2)
+#define ADC_ADEN    (1u << 0)
+#define ADC_ADSTART (1u << 2)
+#define ADC_ADCAL   (1u << 31)
+
+static void hw_init(void)
+{
+    RCC_AHBENR  |= (1u << 17);  /* GPIOA */
+    RCC_APB1ENR |= (1u << 17);  /* USART2 */
+    RCC_APB2ENR |= (1u << 9);   /* ADC1 */
+
+    /* PA0=analog (MODER bits[1:0]=11) */
+    GPIOA_MODER |= (3u << 0);
+
+    /* PA2=TX AF1 */
+    GPIOA_MODER = (GPIOA_MODER & ~(3u << 4)) | (2u << 4);
+    GPIOA_AFRL  = (GPIOA_AFRL  & ~(0xFu << 8)) | (1u << 8);
+
+    USART2_BRR = 417u;
+    USART2_CR1 = (1u << 0) | (1u << 3);  /* UE | TE */
+
+    /* ADC init: synchronous clock PCLK/4 (CKMODE=10 in CFGR2 bits[30:29]) */
+    ADC1_CFGR2 = (2u << 29);   /* CKMODE = PCLK/4 = 12 MHz */
+
+    /* Calibrate */
+    ADC1_CR = ADC_ADCAL;
+    while (ADC1_CR & ADC_ADCAL) {}
+
+    /* Enable */
+    ADC1_CR = ADC_ADEN;
+    while (!(ADC1_ISR & ADC_ADRDY)) {}
+
+    /* Configure: 12-bit, SW trigger, single, channel 0, 239.5 cycles */
+    ADC1_CFGR1  = 0;            /* 12-bit, right-aligned, SW trigger */
+    ADC1_CHSELR = (1u << 0);   /* select CH0 (PA0) */
+    ADC1_SMPR   = 7u;           /* SMP = 111 → 239.5 cycles */
+}
+
+static uint16_t adc_read(void)
+{
+    ADC1_ISR = ADC_EOC;         /* clear flag */
+    ADC1_CR |= ADC_ADSTART;
+    while (!(ADC1_ISR & ADC_EOC)) {}
+    return (uint16_t)(ADC1_DR & 0x0FFFu);
+}
+
+static void uart_putc(char c) { while (!(USART2_ISR & ISR_TXE)) {} USART2_TDR = (uint8_t)c; }
+static void uart_puts(const char *s) { while (*s) uart_putc(*s++); }
+static void uart_putu32(uint32_t n)
+{
+    char buf[10]; uint8_t i = 0;
+    if (!n) { uart_putc('0'); return; }
+    while (n) { buf[i++] = (char)('0' + n % 10u); n /= 10u; }
+    while (i--) uart_putc(buf[i]);
+}
+
+void ktos_timer_irq_handler(void);
+void SysTick_Handler(void) { ktos_timer_irq_handler(); }
+__attribute__((noreturn)) void ktos_Emergency(const char *msg)
+{ uart_puts("\r\n[KTOS FATAL] "); uart_puts(msg); while (1) {} }
+void ktos_DebugPrintf(const char *f, ...) { (void)f; }
+void ktos_InitSys(void) {}
+
+#define SAMPLE_MS 1000U
+
+static WORD adc_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam; (void)lParam;
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        uart_puts("=============================\r\n");
+        uart_puts("  KTOS ADC — Nucleo-F030R8\r\n");
+        uart_puts("  PA0 (A0), 12-bit, 3.3 V ref\r\n");
+        uart_puts("=============================\r\n");
+        return SAMPLE_MS;
+    }
+    uint16_t raw = adc_read();
+    uint32_t mv  = ((uint32_t)raw * 3300UL) / 4095UL;
+    uart_puts("A0: raw="); uart_putu32(raw);
+    uart_puts("  "); uart_putu32(mv); uart_puts(" mV\r\n");
+    return SAMPLE_MS;
+}
+
+int main(void)
+{
+    hw_init();
+    ktos_InitTask(adc_task, 256, 4, 'A');
+    ktos_RunOS();
+    return 0;
+}

--- a/examples/stm32f030/button_control/platformio.ini
+++ b/examples/stm32f030/button_control/platformio.ini
@@ -1,0 +1,18 @@
+; KTOS — STM32F030 Nucleo button control example (bare-metal)
+
+[env:nucleo_f030r8]
+platform             = ststm32
+board                = nucleo_f030r8
+upload_protocol      = stlink
+monitor_speed        = 115200
+board_build.ldscript = ../../../bsp/stm32f030/stm32f030.ld
+build_src_filter =
+    +<*>
+    +<../../../../core/ktos.c>
+    +<../../../../bsp/stm32f030/ktos_bsp.c>
+    +<../../../../bsp/stm32f030/startup.c>
+build_flags =
+    -mcpu=cortex-m0 -mthumb -DF_CPU=48000000UL
+    -Wall -Wextra -Os -ffunction-sections -fdata-sections
+    -Wl,--gc-sections --specs=nosys.specs
+    -I../../../core -I../../../bsp/stm32f030

--- a/examples/stm32f030/button_control/src/main.c
+++ b/examples/stm32f030/button_control/src/main.c
@@ -1,0 +1,130 @@
+/*
+ * KTOS — STM32F030 Nucleo-F030R8 button control example (bare-metal)
+ *
+ * Two cooperating KTOS tasks:
+ *
+ *   btn_task ('B') — polls PC13 (B1 USER button, active low) every 5 ms
+ *                    with a 30 ms debouncer. On confirmed press, sends
+ *                    MSG_BUTTON_EVENT to led_task.
+ *
+ *   led_task ('L') — toggles PA5 (LD2, active high) on each event
+ *                    and reports via USART2.
+ *
+ * Hardware (all on-board on Nucleo):
+ *   PC13 — B1 USER button (active low, board pull-up)
+ *   PA5  — LD2 onboard LED (active high)
+ *   PA2  — USART2 TX → ST-Link virtual COM port
+ */
+
+#include <stdint.h>
+#include "../../../../core/ktos.h"
+
+#define RCC_AHBENR   (*(volatile uint32_t *)0x40021014UL)
+#define RCC_APB1ENR  (*(volatile uint32_t *)0x4002101CUL)
+
+#define GPIOA_MODER  (*(volatile uint32_t *)0x48000000UL)
+#define GPIOA_ODR    (*(volatile uint32_t *)0x48000014UL)
+#define GPIOA_BSRR   (*(volatile uint32_t *)0x48000018UL)
+#define GPIOA_AFRL   (*(volatile uint32_t *)0x48000020UL)
+
+#define GPIOC_MODER  (*(volatile uint32_t *)0x48000800UL)
+#define GPIOC_PUPDR  (*(volatile uint32_t *)0x4800080CUL)
+#define GPIOC_IDR    (*(volatile uint32_t *)0x48000810UL)
+
+#define USART2_CR1   (*(volatile uint32_t *)0x40004400UL)
+#define USART2_BRR   (*(volatile uint32_t *)0x4000440CUL)
+#define USART2_ISR   (*(volatile uint32_t *)0x4000441CUL)
+#define USART2_TDR   (*(volatile uint32_t *)0x40004428UL)
+#define ISR_TXE  (1u << 7)
+
+#define LED_PIN   5u
+#define BTN_PIN  13u
+#define LED_ON()   GPIOA_BSRR = (1u << LED_PIN)
+#define LED_OFF()  GPIOA_BSRR = (1u << (LED_PIN + 16u))
+#define BTN_PRESSED()  (!(GPIOC_IDR & (1u << BTN_PIN)))
+
+static void hw_init(void)
+{
+    RCC_AHBENR  |= (1u << 17) | (1u << 19);  /* GPIOA + GPIOC */
+    RCC_APB1ENR |= (1u << 17);                /* USART2 */
+
+    /* PA2=TX AF1 */
+    GPIOA_MODER = (GPIOA_MODER & ~(3u << 4)) | (2u << 4);
+    GPIOA_AFRL  = (GPIOA_AFRL  & ~(0xFu << 8)) | (1u << 8);
+
+    /* PA5=output */
+    GPIOA_MODER = (GPIOA_MODER & ~(3u << 10)) | (1u << 10);
+    LED_OFF();
+
+    /* PC13=input, pull-up */
+    GPIOC_MODER &= ~(3u << 26);         /* input */
+    GPIOC_PUPDR  = (GPIOC_PUPDR & ~(3u << 26)) | (1u << 26);  /* pull-up */
+
+    USART2_BRR = 417u;
+    USART2_CR1 = (1u << 0) | (1u << 3);  /* UE | TE */
+}
+
+static void uart_putc(char c) { while (!(USART2_ISR & ISR_TXE)) {} USART2_TDR = (uint8_t)c; }
+static void uart_puts(const char *s) { while (*s) uart_putc(*s++); }
+
+void ktos_timer_irq_handler(void);
+void SysTick_Handler(void) { ktos_timer_irq_handler(); }
+__attribute__((noreturn)) void ktos_Emergency(const char *msg)
+{ uart_puts("\r\n[KTOS FATAL] "); uart_puts(msg); while (1) {} }
+void ktos_DebugPrintf(const char *f, ...) { (void)f; }
+void ktos_InitSys(void) {}
+
+#define MSG_BUTTON_EVENT  ((WORD)(KTOS_MSG_TYPE_SYSTEM_START + 1))
+#define DEBOUNCE_MS  30U
+#define POLL_MS       5U
+
+static struct ktos_TASK *g_led_task;
+static uint32_t g_press_count;
+
+static WORD led_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam; (void)lParam;
+    if (MsgType == KTOS_MSG_TYPE_INIT) { LED_OFF(); return MSG_WAIT; }
+    if (MsgType != MSG_BUTTON_EVENT)   { return MSG_WAIT; }
+    ++g_press_count;
+    GPIOA_ODR ^= (1u << LED_PIN);
+    uart_puts("Button #");
+    uint32_t n = g_press_count;
+    char buf[11]; uint8_t i = 0;
+    do { buf[i++] = (char)('0' + n % 10u); n /= 10u; } while (n);
+    while (i--) uart_putc(buf[i]);
+    uart_puts(" — LD2 toggled\r\n");
+    return MSG_WAIT;
+}
+
+static WORD btn_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam; (void)lParam;
+    static uint8_t last_state  = 0;
+    static uint8_t debounce_ms = 0;
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        uart_puts("=============================\r\n");
+        uart_puts("  KTOS Button Control\r\n");
+        uart_puts("  B1(PC13) → LD2(PA5)\r\n");
+        uart_puts("  30 ms debounce\r\n");
+        uart_puts("=============================\r\n");
+        return POLL_MS;
+    }
+    uint8_t pressed = BTN_PRESSED() ? 1u : 0u;
+    if (pressed != last_state) { debounce_ms = 0; last_state = pressed; }
+    else if (debounce_ms < DEBOUNCE_MS) {
+        debounce_ms = (uint8_t)(debounce_ms + POLL_MS);
+        if (debounce_ms >= DEBOUNCE_MS && pressed)
+            ktos_SendMsg(g_led_task, MSG_BUTTON_EVENT, 0, 0);
+    }
+    return POLL_MS;
+}
+
+int main(void)
+{
+    hw_init();
+    g_led_task = ktos_InitTask(led_task, 256, 4, 'L');
+    ktos_InitTask(btn_task, 256, 4, 'B');
+    ktos_RunOS();
+    return 0;
+}

--- a/examples/stm32f030/i2c/platformio.ini
+++ b/examples/stm32f030/i2c/platformio.ini
@@ -1,0 +1,18 @@
+; KTOS — STM32F030 Nucleo I2C scanner example (bare-metal)
+
+[env:nucleo_f030r8]
+platform             = ststm32
+board                = nucleo_f030r8
+upload_protocol      = stlink
+monitor_speed        = 115200
+board_build.ldscript = ../../../bsp/stm32f030/stm32f030.ld
+build_src_filter =
+    +<*>
+    +<../../../../core/ktos.c>
+    +<../../../../bsp/stm32f030/ktos_bsp.c>
+    +<../../../../bsp/stm32f030/startup.c>
+build_flags =
+    -mcpu=cortex-m0 -mthumb -DF_CPU=48000000UL
+    -Wall -Wextra -Os -ffunction-sections -fdata-sections
+    -Wl,--gc-sections --specs=nosys.specs
+    -I../../../core -I../../../bsp/stm32f030

--- a/examples/stm32f030/i2c/src/main.c
+++ b/examples/stm32f030/i2c/src/main.c
@@ -1,0 +1,155 @@
+/*
+ * KTOS — STM32F030 Nucleo-F030R8 I2C scanner example (bare-metal)
+ *
+ * Single KTOS task scans I2C1 (100 kHz) for devices at 0x01–0x7E every 5 s.
+ * Results printed over USART2 (ST-Link virtual COM).
+ *
+ * I2C1 pins: PB6=SCL, PB7=SDA, AF1, open-drain.  Add 4.7 kΩ pull-ups.
+ * APB clock = 48 MHz.
+ * TIMINGR = 0xB0420F13 (AN4235 Table 9: 48 MHz, 100 kHz, analog filter on).
+ *
+ * STM32F030 I2C uses new-style registers (TIMINGR, CR2 with AUTOEND/START).
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "../../../../core/ktos.h"
+
+#define RCC_AHBENR   (*(volatile uint32_t *)0x40021014UL)
+#define RCC_APB1ENR  (*(volatile uint32_t *)0x4002101CUL)
+
+#define GPIOA_MODER  (*(volatile uint32_t *)0x48000000UL)
+#define GPIOA_AFRL   (*(volatile uint32_t *)0x48000020UL)
+
+#define GPIOB_MODER  (*(volatile uint32_t *)0x48000400UL)
+#define GPIOB_OTYPER (*(volatile uint32_t *)0x48000404UL)
+#define GPIOB_AFRL   (*(volatile uint32_t *)0x48000420UL)
+
+#define USART2_CR1   (*(volatile uint32_t *)0x40004400UL)
+#define USART2_BRR   (*(volatile uint32_t *)0x4000440CUL)
+#define USART2_ISR   (*(volatile uint32_t *)0x4000441CUL)
+#define USART2_TDR   (*(volatile uint32_t *)0x40004428UL)
+#define ISR_TXE  (1u << 7)
+
+/* I2C1 new-style registers (base 0x40005400) */
+#define I2C1_CR1     (*(volatile uint32_t *)0x40005400UL)
+#define I2C1_CR2     (*(volatile uint32_t *)0x40005404UL)
+#define I2C1_TIMINGR (*(volatile uint32_t *)0x40005410UL)
+#define I2C1_ISR     (*(volatile uint32_t *)0x40005418UL)
+#define I2C1_ICR     (*(volatile uint32_t *)0x4000541CUL)
+
+#define I2C_PE      (1u << 0)
+#define I2C_START   (1u << 13)
+#define I2C_AUTOEND (1u << 25)
+#define I2C_NACKF   (1u << 4)
+#define I2C_STOPF   (1u << 5)
+#define I2C_BUSY    (1u << 15)
+
+static void hw_init(void)
+{
+    RCC_AHBENR  |= (1u << 17) | (1u << 18);  /* GPIOA + GPIOB */
+    RCC_APB1ENR |= (1u << 17) | (1u << 21);  /* USART2 + I2C1 */
+
+    /* PA2=TX AF1 */
+    GPIOA_MODER = (GPIOA_MODER & ~(3u << 4)) | (2u << 4);
+    GPIOA_AFRL  = (GPIOA_AFRL  & ~(0xFu << 8)) | (1u << 8);
+
+    /* PB6=SCL, PB7=SDA: AF mode, open-drain, AF1 */
+    GPIOB_MODER = (GPIOB_MODER & ~(0xFFu << 12))
+                | (2u << 12)   /* PB6 AF */
+                | (2u << 14);  /* PB7 AF */
+    GPIOB_OTYPER |= (1u << 6) | (1u << 7);  /* open-drain */
+    GPIOB_AFRL = (GPIOB_AFRL & ~(0xFFu << 24))
+               | (1u << 24)   /* PB6 AF1 */
+               | (1u << 28);  /* PB7 AF1 */
+
+    USART2_BRR = 417u;
+    USART2_CR1 = (1u << 0) | (1u << 3);  /* UE | TE */
+
+    /* I2C1: 100 kHz at 48 MHz (AN4235 Table 9, analog filter on) */
+    I2C1_CR1     = 0;           /* disable while configuring */
+    I2C1_TIMINGR = 0xB0420F13UL;
+    I2C1_CR1     = I2C_PE;
+}
+
+static void uart_putc(char c) { while (!(USART2_ISR & ISR_TXE)) {} USART2_TDR = (uint8_t)c; }
+static void uart_puts(const char *s) { while (*s) uart_putc(*s++); }
+static void uart_put_hex2(uint8_t b)
+{
+    const char h[] = "0123456789ABCDEF";
+    uart_putc(h[b >> 4]); uart_putc(h[b & 0xFu]);
+}
+static void uart_putu8(uint8_t n)
+{
+    char buf[4]; uint8_t i = 0;
+    if (!n) { uart_putc('0'); return; }
+    while (n) { buf[i++] = (char)('0' + n % 10u); n = (uint8_t)(n / 10u); }
+    while (i--) uart_putc(buf[i]);
+}
+
+void ktos_timer_irq_handler(void);
+void SysTick_Handler(void) { ktos_timer_irq_handler(); }
+__attribute__((noreturn)) void ktos_Emergency(const char *msg)
+{ uart_puts("\r\n[KTOS FATAL] "); uart_puts(msg); while (1) {} }
+void ktos_DebugPrintf(const char *f, ...) { (void)f; }
+void ktos_InitSys(void) {}
+
+static bool i2c_probe(uint8_t addr)
+{
+    /* Wait bus idle */
+    while (I2C1_ISR & I2C_BUSY) {}
+
+    /* Clear flags then start: SADD=addr<<1, NBYTES=0, AUTOEND, START */
+    I2C1_ICR = I2C_NACKF | I2C_STOPF;
+    I2C1_CR2 = ((uint32_t)addr << 1) | I2C_AUTOEND | I2C_START;
+
+    /* Wait for NACKF (no device) or STOPF (device ACKed) */
+    uint32_t isr;
+    do { isr = I2C1_ISR; } while (!((isr & I2C_NACKF) || (isr & I2C_STOPF)));
+
+    bool found = !(I2C1_ISR & I2C_NACKF);
+    I2C1_ICR = I2C_NACKF | I2C_STOPF;
+    return found;
+}
+
+static void run_scan(void)
+{
+    uart_puts("Scanning I2C bus (0x01–0x7E)...\r\n");
+    uint8_t found = 0;
+    for (uint8_t addr = 0x01u; addr <= 0x7Eu; ++addr) {
+        if (i2c_probe(addr)) {
+            uart_puts("  Found: 0x"); uart_put_hex2(addr); uart_puts("\r\n");
+            ++found;
+        }
+    }
+    if (!found) { uart_puts("No I2C devices found.\r\n"); }
+    else { uart_putu8(found); uart_puts(" device(s) found.\r\n"); }
+    uart_puts("\r\n");
+}
+
+#define SCAN_PERIOD_MS 5000U
+
+static WORD scanner_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam; (void)lParam;
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        uart_puts("=============================\r\n");
+        uart_puts("  KTOS I2C Scanner\r\n");
+        uart_puts("  Nucleo-F030R8\r\n");
+        uart_puts("  PB6=SCL  PB7=SDA  100 kHz\r\n");
+        uart_puts("  4.7k pull-ups required\r\n");
+        uart_puts("=============================\r\n");
+        run_scan();
+        return SCAN_PERIOD_MS;
+    }
+    run_scan();
+    return SCAN_PERIOD_MS;
+}
+
+int main(void)
+{
+    hw_init();
+    ktos_InitTask(scanner_task, 512, 4, 'I');
+    ktos_RunOS();
+    return 0;
+}

--- a/examples/stm32f030/led_control/platformio.ini
+++ b/examples/stm32f030/led_control/platformio.ini
@@ -1,0 +1,18 @@
+; KTOS — STM32F030 Nucleo LED control example (bare-metal)
+
+[env:nucleo_f030r8]
+platform             = ststm32
+board                = nucleo_f030r8
+upload_protocol      = stlink
+monitor_speed        = 115200
+board_build.ldscript = ../../../bsp/stm32f030/stm32f030.ld
+build_src_filter =
+    +<*>
+    +<../../../../core/ktos.c>
+    +<../../../../bsp/stm32f030/ktos_bsp.c>
+    +<../../../../bsp/stm32f030/startup.c>
+build_flags =
+    -mcpu=cortex-m0 -mthumb -DF_CPU=48000000UL
+    -Wall -Wextra -Os -ffunction-sections -fdata-sections
+    -Wl,--gc-sections --specs=nosys.specs
+    -I../../../core -I../../../bsp/stm32f030

--- a/examples/stm32f030/led_control/src/main.c
+++ b/examples/stm32f030/led_control/src/main.c
@@ -1,0 +1,144 @@
+/*
+ * KTOS — STM32F030 Nucleo-F030R8 LED control example (bare-metal)
+ *
+ * Two cooperating KTOS tasks:
+ *
+ *   uart_task ('U') — polls USART2 every 10 ms, parses commands:
+ *                       ON  → ktos_SendMsg(led_task, MSG_SET_MODE, MODE_ON)
+ *                       OFF → ktos_SendMsg(led_task, MSG_SET_MODE, MODE_OFF)
+ *                       TOG → ktos_SendMsg(led_task, MSG_SET_MODE, MODE_TOGGLE)
+ *
+ *   led_task  ('L') — controls PA5 (LD2 on Nucleo, active high).
+ *                     In TOGGLE mode, flips every 500 ms.
+ *
+ * USART2: PA2=TX, PA3=RX (ST-Link virtual COM), 115200 8N1.
+ * LED LD2: PA5 (active high).
+ * No external hardware required.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include "../../../../core/ktos.h"
+
+#define RCC_AHBENR   (*(volatile uint32_t *)0x40021014UL)
+#define RCC_APB1ENR  (*(volatile uint32_t *)0x4002101CUL)
+
+#define GPIOA_MODER  (*(volatile uint32_t *)0x48000000UL)
+#define GPIOA_ODR    (*(volatile uint32_t *)0x48000014UL)
+#define GPIOA_BSRR   (*(volatile uint32_t *)0x48000018UL)
+#define GPIOA_AFRL   (*(volatile uint32_t *)0x48000020UL)
+
+#define USART2_CR1   (*(volatile uint32_t *)0x40004400UL)
+#define USART2_BRR   (*(volatile uint32_t *)0x4000440CUL)
+#define USART2_ISR   (*(volatile uint32_t *)0x4000441CUL)
+#define USART2_RDR   (*(volatile uint32_t *)0x40004424UL)
+#define USART2_TDR   (*(volatile uint32_t *)0x40004428UL)
+#define ISR_TXE  (1u << 7)
+#define ISR_RXNE (1u << 5)
+
+#define LED_PIN  5u
+#define LED_ON()   GPIOA_BSRR = (1u << LED_PIN)
+#define LED_OFF()  GPIOA_BSRR = (1u << (LED_PIN + 16u))
+
+static void hw_init(void)
+{
+    RCC_AHBENR  |= (1u << 17);  /* GPIOA */
+    RCC_APB1ENR |= (1u << 17);  /* USART2 */
+
+    /* PA2=TX AF1, PA3=RX AF1, PA5=output */
+    GPIOA_MODER = (GPIOA_MODER & ~(0xF0Fu << 4))
+                | (2u << 4)    /* PA2 AF */
+                | (2u << 6)    /* PA3 AF */
+                | (1u << 10);  /* PA5 output */
+
+    GPIOA_AFRL = (GPIOA_AFRL & ~(0xFFu << 8))
+               | (1u << 8) | (1u << 12);  /* PA2/PA3 AF1 */
+
+    LED_OFF();
+    USART2_BRR = 417u;
+    USART2_CR1 = (1u << 0) | (1u << 3) | (1u << 2);
+}
+
+static void uart_putc(char c) { while (!(USART2_ISR & ISR_TXE)) {} USART2_TDR = (uint8_t)c; }
+static void uart_puts(const char *s) { while (*s) uart_putc(*s++); }
+static int16_t uart_getc(void)
+{
+    if (!(USART2_ISR & ISR_RXNE)) { return -1; }
+    return (int16_t)(USART2_RDR & 0xFFu);
+}
+
+void ktos_timer_irq_handler(void);
+void SysTick_Handler(void) { ktos_timer_irq_handler(); }
+__attribute__((noreturn)) void ktos_Emergency(const char *msg)
+{ uart_puts("\r\n[KTOS FATAL] "); uart_puts(msg); while (1) {} }
+void ktos_DebugPrintf(const char *f, ...) { (void)f; }
+void ktos_InitSys(void) {}
+
+#define MSG_SET_MODE  ((WORD)(KTOS_MSG_TYPE_SYSTEM_START + 1))
+#define MODE_OFF      0U
+#define MODE_ON       1U
+#define MODE_TOGGLE   2U
+#define TOGGLE_MS     500U
+#define RX_POLL_MS    10U
+#define LINE_BUF      16U
+
+static struct ktos_TASK *g_led_task;
+
+static WORD led_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)lParam;
+    static uint8_t mode = MODE_OFF;
+    if (MsgType == KTOS_MSG_TYPE_INIT) { LED_OFF(); return MSG_WAIT; }
+    if (MsgType == MSG_SET_MODE) {
+        mode = (uint8_t)sParam;
+        switch (mode) {
+        case MODE_ON:  LED_ON();  uart_puts("LED: ON\r\n");        return MSG_WAIT;
+        case MODE_OFF: LED_OFF(); uart_puts("LED: OFF\r\n");       return MSG_WAIT;
+        default:                  uart_puts("LED: TOGGLE 500ms\r\n"); return TOGGLE_MS;
+        }
+    }
+    if (mode == MODE_TOGGLE) { GPIOA_ODR ^= (1u << LED_PIN); }
+    return TOGGLE_MS;
+}
+
+static WORD uart_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam; (void)lParam;
+    static char buf[LINE_BUF];
+    static uint8_t len = 0;
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        uart_puts("=============================\r\n");
+        uart_puts("  KTOS LED Control\r\n");
+        uart_puts("  LD2 (PA5)  Commands: ON OFF TOG\r\n");
+        uart_puts("=============================\r\n");
+        len = 0; return RX_POLL_MS;
+    }
+    int16_t b;
+    while ((b = uart_getc()) >= 0) {
+        char c = (char)b;
+        uart_putc(c);
+        if (c == '\r') { uart_putc('\n'); }
+        if (c == '\r' || c == '\n') {
+            buf[len] = '\0';
+            if (strcmp(buf, "ON") == 0 || strcmp(buf, "on") == 0)
+                ktos_SendMsg(g_led_task, MSG_SET_MODE, MODE_ON, 0);
+            else if (strcmp(buf, "OFF") == 0 || strcmp(buf, "off") == 0)
+                ktos_SendMsg(g_led_task, MSG_SET_MODE, MODE_OFF, 0);
+            else if (strcmp(buf, "TOG") == 0 || strcmp(buf, "tog") == 0)
+                ktos_SendMsg(g_led_task, MSG_SET_MODE, MODE_TOGGLE, 0);
+            else if (len > 0) uart_puts("Commands: ON  OFF  TOG\r\n");
+            len = 0; continue;
+        }
+        if (len < (LINE_BUF - 1)) { buf[len++] = c; }
+    }
+    return RX_POLL_MS;
+}
+
+int main(void)
+{
+    hw_init();
+    g_led_task = ktos_InitTask(led_task,  256, 4, 'L');
+    ktos_InitTask(uart_task, 256, 4, 'U');
+    ktos_RunOS();
+    return 0;
+}

--- a/examples/stm32f030/spi/platformio.ini
+++ b/examples/stm32f030/spi/platformio.ini
@@ -1,0 +1,18 @@
+; KTOS — STM32F030 Nucleo SPI loopback example (bare-metal)
+
+[env:nucleo_f030r8]
+platform             = ststm32
+board                = nucleo_f030r8
+upload_protocol      = stlink
+monitor_speed        = 115200
+board_build.ldscript = ../../../bsp/stm32f030/stm32f030.ld
+build_src_filter =
+    +<*>
+    +<../../../../core/ktos.c>
+    +<../../../../bsp/stm32f030/ktos_bsp.c>
+    +<../../../../bsp/stm32f030/startup.c>
+build_flags =
+    -mcpu=cortex-m0 -mthumb -DF_CPU=48000000UL
+    -Wall -Wextra -Os -ffunction-sections -fdata-sections
+    -Wl,--gc-sections --specs=nosys.specs
+    -I../../../core -I../../../bsp/stm32f030

--- a/examples/stm32f030/spi/src/main.c
+++ b/examples/stm32f030/spi/src/main.c
@@ -1,0 +1,135 @@
+/*
+ * KTOS — STM32F030 Nucleo-F030R8 SPI loopback example (bare-metal)
+ *
+ * Single KTOS task exercises SPI1 master in external loopback mode.
+ * Sends bytes 0x00–0xFF every 2 s, prints PASS / fail count.
+ *
+ * SPI1 pins (AF0 on GPIOA):
+ *   PA5 = SCK   (also LD2 LED — LED inactive while SPI runs)
+ *   PA6 = MISO
+ *   PA7 = MOSI
+ *
+ * Loopback: bridge PA6 (MISO) to PA7 (MOSI) with a jumper wire.
+ * STM32F030 SPI has no hardware loopback bit.
+ *
+ * SPI clock: APB (48 MHz) / 8 → 6 MHz (BR=010).
+ * USART2: PA2=TX, 115200 8N1 → ST-Link virtual COM.
+ */
+
+#include <stdint.h>
+#include "../../../../core/ktos.h"
+
+#define RCC_AHBENR   (*(volatile uint32_t *)0x40021014UL)
+#define RCC_APB1ENR  (*(volatile uint32_t *)0x4002101CUL)
+#define RCC_APB2ENR  (*(volatile uint32_t *)0x40021018UL)
+
+#define GPIOA_MODER  (*(volatile uint32_t *)0x48000000UL)
+#define GPIOA_AFRL   (*(volatile uint32_t *)0x48000020UL)
+
+#define USART2_CR1   (*(volatile uint32_t *)0x40004400UL)
+#define USART2_BRR   (*(volatile uint32_t *)0x4000440CUL)
+#define USART2_ISR   (*(volatile uint32_t *)0x4000441CUL)
+#define USART2_TDR   (*(volatile uint32_t *)0x40004428UL)
+#define ISR_TXE  (1u << 7)
+
+#define SPI1_CR1     (*(volatile uint32_t *)0x40013000UL)
+#define SPI1_SR      (*(volatile uint32_t *)0x40013008UL)
+#define SPI1_DR_BYTE (*(volatile uint8_t  *)0x4001300CUL)
+#define SPI_TXE  (1u << 1)
+#define SPI_RXNE (1u << 0)
+#define SPI_BSY  (1u << 7)
+
+static void hw_init(void)
+{
+    RCC_AHBENR  |= (1u << 17);  /* GPIOA */
+    RCC_APB1ENR |= (1u << 17);  /* USART2 */
+    RCC_APB2ENR |= (1u << 12);  /* SPI1 */
+
+    /* PA2=TX AF1, PA5=SCK AF0, PA6=MISO input(AF0), PA7=MOSI AF0 */
+    GPIOA_MODER = (GPIOA_MODER & ~(0x3FFFu << 4))
+                | (2u << 4)    /* PA2  AF  */
+                | (2u << 10)   /* PA5  AF  */
+                | (2u << 12)   /* PA6  AF  */
+                | (2u << 14);  /* PA7  AF  */
+
+    /* AFRL: PA2=AF1, PA5/PA6/PA7=AF0 (already 0) */
+    GPIOA_AFRL = (GPIOA_AFRL & ~(0xFu << 8)) | (1u << 8);  /* PA2 AF1 */
+
+    USART2_BRR = 417u;
+    USART2_CR1 = (1u << 0) | (1u << 3);  /* UE | TE */
+
+    /* SPI1 master: BR=010(÷8=6MHz), CPOL=0, CPHA=0, SSM+SSI=1, SPE=1 */
+    SPI1_CR1 = (1u << 2)   /* MSTR */
+             | (2u << 3)   /* BR = /8 */
+             | (1u << 9)   /* SSM */
+             | (1u << 8)   /* SSI */
+             | (1u << 6);  /* SPE */
+}
+
+static uint8_t spi_transfer(uint8_t b)
+{
+    while (!(SPI1_SR & SPI_TXE)) {}
+    SPI1_DR_BYTE = b;
+    while (!(SPI1_SR & SPI_RXNE)) {}
+    return SPI1_DR_BYTE;
+}
+
+static void uart_putc(char c) { while (!(USART2_ISR & ISR_TXE)) {} USART2_TDR = (uint8_t)c; }
+static void uart_puts(const char *s) { while (*s) uart_putc(*s++); }
+static void uart_put_hex2(uint8_t b)
+{
+    const char h[] = "0123456789ABCDEF";
+    uart_putc(h[b >> 4]); uart_putc(h[b & 0xFu]);
+}
+static void uart_putu32(uint32_t n)
+{
+    char buf[10]; uint8_t i = 0;
+    if (!n) { uart_putc('0'); return; }
+    while (n) { buf[i++] = (char)('0' + n % 10u); n /= 10u; }
+    while (i--) uart_putc(buf[i]);
+}
+
+void ktos_timer_irq_handler(void);
+void SysTick_Handler(void) { ktos_timer_irq_handler(); }
+__attribute__((noreturn)) void ktos_Emergency(const char *msg)
+{ uart_puts("\r\n[KTOS FATAL] "); uart_puts(msg); while (1) {} }
+void ktos_DebugPrintf(const char *f, ...) { (void)f; }
+void ktos_InitSys(void) {}
+
+#define TEST_PERIOD_MS 2000U
+
+static WORD spi_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam; (void)lParam;
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        uart_puts("=============================\r\n");
+        uart_puts("  KTOS SPI Loopback\r\n");
+        uart_puts("  Nucleo-F030R8\r\n");
+        uart_puts("  SPI1 @ 6 MHz\r\n");
+        uart_puts("  Bridge PA6(MISO)–PA7(MOSI)\r\n");
+        uart_puts("=============================\r\n");
+        return TEST_PERIOD_MS;
+    }
+    uint32_t errors = 0;
+    for (uint16_t i = 0; i <= 0xFFu; ++i) {
+        uint8_t sent = (uint8_t)i;
+        uint8_t recv = spi_transfer(sent);
+        if (recv != sent) {
+            uart_puts("  ERR sent=0x"); uart_put_hex2(sent);
+            uart_puts(" got=0x"); uart_put_hex2(recv); uart_puts("\r\n");
+            ++errors;
+        }
+    }
+    uart_puts("SPI 0x00–0xFF: ");
+    if (!errors) { uart_puts("PASS\r\n"); }
+    else { uart_putu32(errors); uart_puts(" error(s) — FAIL\r\n"); }
+    return TEST_PERIOD_MS;
+}
+
+int main(void)
+{
+    hw_init();
+    ktos_InitTask(spi_task, 256, 4, 'S');
+    ktos_RunOS();
+    return 0;
+}

--- a/examples/stm32f030/uart/platformio.ini
+++ b/examples/stm32f030/uart/platformio.ini
@@ -1,0 +1,18 @@
+; KTOS — STM32F030 Nucleo UART example (bare-metal)
+
+[env:nucleo_f030r8]
+platform             = ststm32
+board                = nucleo_f030r8
+upload_protocol      = stlink
+monitor_speed        = 115200
+board_build.ldscript = ../../../bsp/stm32f030/stm32f030.ld
+build_src_filter =
+    +<*>
+    +<../../../../core/ktos.c>
+    +<../../../../bsp/stm32f030/ktos_bsp.c>
+    +<../../../../bsp/stm32f030/startup.c>
+build_flags =
+    -mcpu=cortex-m0 -mthumb -DF_CPU=48000000UL
+    -Wall -Wextra -Os -ffunction-sections -fdata-sections
+    -Wl,--gc-sections --specs=nosys.specs
+    -I../../../core -I../../../bsp/stm32f030

--- a/examples/stm32f030/uart/src/main.c
+++ b/examples/stm32f030/uart/src/main.c
@@ -1,0 +1,147 @@
+/*
+ * KTOS — STM32F030 Nucleo-F030R8 UART example (bare-metal)
+ *
+ * Two cooperating KTOS tasks form a tiny shell over USART2:
+ *
+ *   rx_task ('R') — polls every 10 ms, drains USART2 RX, echoes bytes,
+ *                   assembles lines, posts MSG_LINE_READY to cmd_task.
+ *   cmd_task ('C') — waits MSG_LINE_READY, dispatches PING/INFO/HELP.
+ *
+ * USART2 is connected to the ST-Link virtual COM port on Nucleo:
+ *   PA2 = TX (AF1), PA3 = RX (AF1), 115200 8N1, 48 MHz APB.
+ *   BRR = 48000000/115200 = 417 (mantissa=26, fraction=1).
+ *
+ * Tick: SysTick → 1 ms at 48 MHz (LOAD = 47999).
+ * Clock: HSI 8 MHz → HSI/2 (4 MHz) → PLL ×12 = 48 MHz (set by startup.c).
+ *
+ * No external hardware required — just the Nucleo and a USB cable.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include "../../../../core/ktos.h"
+
+/* =========================================================================
+ * RCC / GPIO (STM32F0: GPIO clocks in AHBENR, GPIO base 0x4800xxxx)
+ * USART2 (STM32F0 new register map: ISR, TDR, RDR)
+ * ========================================================================= */
+#define RCC_AHBENR   (*(volatile uint32_t *)0x40021014UL)
+#define RCC_APB1ENR  (*(volatile uint32_t *)0x4002101CUL)
+
+#define GPIOA_MODER  (*(volatile uint32_t *)0x48000000UL)
+#define GPIOA_AFRL   (*(volatile uint32_t *)0x48000020UL)
+
+#define USART2_CR1   (*(volatile uint32_t *)0x40004400UL)
+#define USART2_BRR   (*(volatile uint32_t *)0x4000440CUL)
+#define USART2_ISR   (*(volatile uint32_t *)0x4000441CUL)
+#define USART2_RDR   (*(volatile uint32_t *)0x40004424UL)
+#define USART2_TDR   (*(volatile uint32_t *)0x40004428UL)
+
+#define ISR_TXE  (1u << 7)
+#define ISR_RXNE (1u << 5)
+
+static void usart2_init(void)
+{
+    RCC_AHBENR  |= (1u << 17);  /* GPIOA clock */
+    RCC_APB1ENR |= (1u << 17);  /* USART2 clock */
+
+    /* PA2=TX, PA3=RX → AF1: MODER bits[5:4]=10, bits[7:6]=10 */
+    GPIOA_MODER = (GPIOA_MODER & ~(0xFFu << 4))
+                | (2u << 4)    /* PA2 AF */
+                | (2u << 6);   /* PA3 AF */
+
+    /* AFRL: PA2 bits[11:8]=0001, PA3 bits[15:12]=0001 */
+    GPIOA_AFRL = (GPIOA_AFRL & ~(0xFFu << 8))
+               | (1u << 8)    /* PA2 AF1 */
+               | (1u << 12);  /* PA3 AF1 */
+
+    USART2_BRR = 417u;                          /* 115200 at 48 MHz */
+    USART2_CR1 = (1u << 0) | (1u << 3) | (1u << 2);  /* UE | TE | RE */
+}
+
+static void uart_putc(char c)
+{
+    while (!(USART2_ISR & ISR_TXE)) {}
+    USART2_TDR = (uint8_t)c;
+}
+static void uart_puts(const char *s) { while (*s) uart_putc(*s++); }
+static int16_t uart_getc(void)
+{
+    if (!(USART2_ISR & ISR_RXNE)) { return -1; }
+    return (int16_t)(USART2_RDR & 0xFFu);
+}
+
+void ktos_timer_irq_handler(void);
+void SysTick_Handler(void) { ktos_timer_irq_handler(); }
+__attribute__((noreturn)) void ktos_Emergency(const char *msg)
+{ uart_puts("\r\n[KTOS FATAL] "); uart_puts(msg); while (1) {} }
+void ktos_DebugPrintf(const char *f, ...) { (void)f; }
+void ktos_InitSys(void) {}
+
+/* =========================================================================
+ * Tasks
+ * ========================================================================= */
+#define MSG_LINE_READY  ((WORD)(KTOS_MSG_TYPE_SYSTEM_START + 1))
+#define LINE_BUF_SIZE   64U
+#define RX_POLL_MS      10U
+
+static char    g_line[LINE_BUF_SIZE];
+static uint8_t g_line_len;
+static struct ktos_TASK *g_cmd_task;
+
+static WORD cmd_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam; (void)lParam;
+    if (MsgType == KTOS_MSG_TYPE_INIT) {
+        uart_puts("=============================\r\n");
+        uart_puts("  KTOS UART — Nucleo-F030R8\r\n");
+        uart_puts("  USART2  115200 8N1\r\n");
+        uart_puts("  Type HELP for commands.\r\n");
+        uart_puts("=============================\r\n");
+        return MSG_WAIT;
+    }
+    if (MsgType != MSG_LINE_READY) { return MSG_WAIT; }
+    if (strcmp(g_line, "PING") == 0)      { uart_puts("PONG\r\n"); }
+    else if (strcmp(g_line, "INFO") == 0) {
+        uart_puts("Board : STM32F030R8 Nucleo\r\n");
+        uart_puts("Core  : ARM Cortex-M0 @ 48 MHz\r\n");
+        uart_puts("RAM   : 8 KB   Flash: 64 KB\r\n");
+        uart_puts("OS    : KTOS (cooperative)\r\n");
+        uart_puts("Tick  : SysTick 1 ms\r\n");
+    }
+    else if (strcmp(g_line, "HELP") == 0) { uart_puts("Commands: PING  INFO  HELP\r\n"); }
+    else if (g_line[0] != '\0')           { uart_puts("Unknown. Type HELP.\r\n"); }
+    return MSG_WAIT;
+}
+
+static WORD rx_task(WORD MsgType, WORD sParam, LONG lParam)
+{
+    (void)sParam; (void)lParam;
+    if (MsgType == KTOS_MSG_TYPE_INIT) { g_line_len = 0; return RX_POLL_MS; }
+    int16_t b;
+    while ((b = uart_getc()) >= 0) {
+        char c = (char)b;
+        uart_putc(c);
+        if (c == '\r') { uart_putc('\n'); }
+        if (c == '\r' || c == '\n') {
+            if (g_line_len > 0) {
+                g_line[g_line_len] = '\0';
+                ktos_SendMsg(g_cmd_task, MSG_LINE_READY, (WORD)g_line_len, 0);
+                g_line_len = 0;
+            }
+            continue;
+        }
+        char upper = (c >= 'a' && c <= 'z') ? (char)(c - 32) : c;
+        if (g_line_len < (LINE_BUF_SIZE - 1)) { g_line[g_line_len++] = upper; }
+    }
+    return RX_POLL_MS;
+}
+
+int main(void)
+{
+    usart2_init();
+    g_cmd_task = ktos_InitTask(cmd_task, 256, 4, 'C');
+    ktos_InitTask(rx_task, 256, 4, 'R');
+    ktos_RunOS();
+    return 0;
+}


### PR DESCRIPTION
…stm32f030/stm32f030.ld: linker script (64KB flash, 8KB RAM) - Add bsp/stm32f030/startup.c: vector table, 48MHz PLL clock init (HSI/2 x12), data/bss init with uintptr_t casts (cppcheck-clean) Add 6 bare-metal PlatformIO examples: uart, led_control,button_control, adc, i2c, spi

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Tested on hardware platform: <!-- specify which MCU/board -->
- [ ] Unit tests added/updated
- [ ] All existing tests pass
- [ ] Code compiles without warnings

**Test Configuration**:
* MCU/Platform:
* Compiler version:
* Toolchain:

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the pull request here -->

## Related Issues
<!-- Link related issues below. Use "Closes #XX" if this PR closes an issue -->
