### PR TITLE
fix: add _sbrk stub to startup.c to fix bare-metal link error

### DIFF
--- a/bsp/stm32f103/startup.c
+++ b/bsp/stm32f103/startup.c
@@ -215,3 +215,6 @@ void Reset_Handler(void)
     main();
     while (1) {}
 }
+
+  /* Minimal newlib stub — heap unused; prevents _sbrk link error */
+  void *_sbrk(int incr) { (void)incr; return (void *)-1; }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of your changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Tested on hardware platform: <!-- specify which MCU/board -->
- [ ] Unit tests added/updated
- [ ] All existing tests pass
- [ ] Code compiles without warnings

**Test Configuration**:
* MCU/Platform:
* Compiler version:
* Toolchain:

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the pull request here -->

## Related Issues
<!-- Link related issues below. Use "Closes #XX" if this PR closes an issue -->
