### PR TITLE
feat: add NRF52840 BSP and examples [auto-generated]

### DIFF
--- a/bsp/nrf52840/Makefile
+++ b/bsp/nrf52840/Makefile
@@ -1,0 +1,31 @@
+TARGET  = ktos_bsp_nrf52840
+MCU     = cortex-m4
+FPU     = fpv4-sp-d16
+FPABI   = hard
+
+CROSS   = arm-none-eabi-
+CC      = $(CROSS)gcc
+AR      = $(CROSS)ar
+OBJCOPY = $(CROSS)objcopy
+
+KTOS_ROOT ?= ../..
+
+CFLAGS  = -mcpu=$(MCU) -mthumb -mfpu=$(FPU) -mfloat-abi=$(FPABI)
+CFLAGS += -O2 -Wall -Wextra -ffunction-sections -fdata-sections
+CFLAGS += -I$(KTOS_ROOT)/include
+
+SRCS    = ktos_bsp.c
+OBJS    = $(SRCS:.c=.o)
+
+all: lib$(TARGET).a
+
+lib$(TARGET).a: $(OBJS)
+	$(AR) rcs $@ $^
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) lib$(TARGET).a
+
+.PHONY: all clean

--- a/bsp/nrf52840/ktos_bsp.c
+++ b/bsp/nrf52840/ktos_bsp.c
@@ -1,0 +1,111 @@
+#include <stdint.h>
+#include <string.h>
+#include "ktos.h"
+
+/* NRF52840 SysTick and NVIC registers */
+#define SYST_CSR   (*((volatile uint32_t*)0xE000E010))
+#define SYST_RVR   (*((volatile uint32_t*)0xE000E014))
+#define SYST_CVR   (*((volatile uint32_t*)0xE000E018))
+#define ICSR       (*((volatile uint32_t*)0xE000ED04))
+#define SHPR3      (*((volatile uint32_t*)0xE000ED20))
+#define CPU_FREQ   64000000UL
+#define TICK_HZ    1000UL
+
+extern volatile ktos_tcb_t *ktos_current_task;
+extern volatile ktos_tcb_t *ktos_next_task;
+
+void ktos_hal_DisableInterrupts(void) {
+    __asm volatile ("cpsid i" ::: "memory");
+}
+
+void ktos_hal_EnableInterrupts(void) {
+    __asm volatile ("cpsie i" ::: "memory");
+}
+
+uint32_t *ktos_hal_InitTaskStack(uint32_t *stack_top, void (*task_func)(void *), void *arg) {
+    uint32_t *sp = stack_top;
+    *(--sp) = 0x01000000;        /* xPSR: Thumb bit */
+    *(--sp) = (uint32_t)task_func; /* PC */
+    *(--sp) = 0xFFFFFFFD;        /* LR: EXC_RETURN */
+    *(--sp) = 0x12121212;        /* R12 */
+    *(--sp) = 0x03030303;        /* R3 */
+    *(--sp) = 0x02020202;        /* R2 */
+    *(--sp) = 0x01010101;        /* R1 */
+    *(--sp) = (uint32_t)arg;     /* R0 */
+    *(--sp) = 0x11111111;        /* R11 */
+    *(--sp) = 0x10101010;        /* R10 */
+    *(--sp) = 0x09090909;        /* R9 */
+    *(--sp) = 0x08080808;        /* R8 */
+    *(--sp) = 0x07070707;        /* R7 */
+    *(--sp) = 0x06060606;        /* R6 */
+    *(--sp) = 0x05050505;        /* R5 */
+    *(--sp) = 0x04040404;        /* R4 */
+    return sp;
+}
+
+void ktos_hal_ContextSwitch(void) {
+    ICSR = (1UL << 28); /* Trigger PendSV */
+    __asm volatile ("dsb" ::: "memory");
+    __asm volatile ("isb" ::: "memory");
+}
+
+void ktos_hal_InitSystemTimer(void) {
+    SYST_RVR = (CPU_FREQ / TICK_HZ) - 1;
+    SYST_CVR = 0;
+    SYST_CSR = 0x07; /* Enable, tick interrupt, use processor clock */
+    SHPR3 |= (0xFF << 16); /* PendSV lowest priority */
+}
+
+void ktos_hal_StartScheduler(void) {
+    ktos_hal_InitSystemTimer();
+    __asm volatile (
+        "ldr r0, =0xE000ED08  \n"
+        "ldr r0, [r0]         \n"
+        "ldr r0, [r0]         \n"
+        "msr msp, r0          \n"
+        "cpsie i              \n"
+        "svc 0                \n"
+        ::: "memory"
+    );
+}
+
+__attribute__((naked)) void PendSV_Handler(void) {
+    __asm volatile (
+        "cpsid i                    \n"
+        "mrs r0, psp                \n"
+        "stmdb r0!, {r4-r11}        \n"
+        "ldr r1, =ktos_current_task \n"
+        "ldr r1, [r1]               \n"
+        "str r0, [r1]               \n"
+        "ldr r1, =ktos_next_task    \n"
+        "ldr r1, [r1]               \n"
+        "ldr r0, [r1]               \n"
+        "ldr r2, =ktos_current_task \n"
+        "str r1, [r2]               \n"
+        "ldmia r0!, {r4-r11}        \n"
+        "msr psp, r0                \n"
+        "cpsie i                    \n"
+        "bx lr                      \n"
+        ::: "memory"
+    );
+}
+
+void SysTick_Handler(void) {
+    ktos_tick();
+}
+
+void SVC_Handler(void) {
+    __asm volatile (
+        "ldr r1, =ktos_current_task \n"
+        "ldr r1, [r1]               \n"
+        "ldr r0, [r1]               \n"
+        "ldmia r0!, {r4-r11}        \n"
+        "msr psp, r0                \n"
+        "mov r0, #2                 \n"
+        "msr control, r0            \n"
+        "isb                        \n"
+        "pop {r0-r3, r12, lr}       \n"
+        "pop {pc}                   \n"
+        ::: "memory"
+    );
+}

--- a/examples/nrf52840/led_control/platformio.ini
+++ b/examples/nrf52840/led_control/platformio.ini
@@ -1,0 +1,16 @@
+[env:nrf52840_dk]
+platform      = nordicnrf52
+board         = nrf52840_dk
+framework     = none
+build_flags   =
+    -Iinclude
+    -I../../../include
+    -mcpu=cortex-m4
+    -mthumb
+    -mfpu=fpv4-sp-d16
+    -mfloat-abi=hard
+    -O2
+    -Wall
+extra_scripts = pre:../../../scripts/link_ktos.py
+build_src_filter = +<src/> +<../../../bsp/nrf52840/>
+monitor_speed = 115200

--- a/examples/nrf52840/led_control/src/main.c
+++ b/examples/nrf52840/led_control/src/main.c
@@ -1,0 +1,50 @@
+#include <stdint.h>
+#include "ktos.h"
+
+/* NRF52840 GPIO P0 registers */
+#define P0_BASE       0x50000000UL
+#define P0_DIRSET     (*((volatile uint32_t*)(P0_BASE + 0x518)))
+#define P0_OUTSET     (*((volatile uint32_t*)(P0_BASE + 0x508)))
+#define P0_OUTCLR     (*((volatile uint32_t*)(P0_BASE + 0x50C)))
+
+/* LED1 = P0.13 on nRF52840 DK */
+#define LED1_PIN      13
+#define LED1_MASK     (1UL << LED1_PIN)
+
+#define STACK_SIZE    256
+
+static uint32_t task1_stack[STACK_SIZE];
+static uint32_t task2_stack[STACK_SIZE];
+static ktos_tcb_t task1_tcb;
+static ktos_tcb_t task2_tcb;
+
+static void delay(volatile uint32_t count) {
+    while (count--) __asm volatile ("nop");
+}
+
+static void led_on_task(void *arg) {
+    (void)arg;
+    P0_DIRSET = LED1_MASK;
+    while (1) {
+        P0_OUTCLR = LED1_MASK; /* Active low */
+        delay(200000);
+        ktos_yield();
+    }
+}
+
+static void led_off_task(void *arg) {
+    (void)arg;
+    while (1) {
+        P0_OUTSET = LED1_MASK; /* Active low: off */
+        delay(200000);
+        ktos_yield();
+    }
+}
+
+int main(void) {
+    ktos_init();
+    ktos_task_create(&task1_tcb, led_on_task, NULL, task1_stack, STACK_SIZE);
+    ktos_task_create(&task2_tcb, led_off_task, NULL, task2_stack, STACK_SIZE);
+    ktos_start();
+    while (1) {}
+}

--- a/examples/nrf52840/uart/platformio.ini
+++ b/examples/nrf52840/uart/platformio.ini
@@ -1,0 +1,16 @@
+[env:nrf52840_dk]
+platform      = nordicnrf52
+board         = nrf52840_dk
+framework     = none
+build_flags   =
+    -Iinclude
+    -I../../../include
+    -mcpu=cortex-m4
+    -mthumb
+    -mfpu=fpv4-sp-d16
+    -mfloat-abi=hard
+    -O2
+    -Wall
+extra_scripts = pre:../../../scripts/link_ktos.py
+build_src_filter = +<src/> +<../../../bsp/nrf52840/>
+monitor_speed = 115200

--- a/examples/nrf52840/uart/src/main.c
+++ b/examples/nrf52840/uart/src/main.c
@@ -1,0 +1,64 @@
+#include <stdint.h>
+#include <string.h>
+#include "ktos.h"
+
+/* NRF52840 UART0 (UARTE0) */
+#define UARTE0_BASE       0x40002000UL
+#define UARTE0_STARTTX    (*((volatile uint32_t*)(UARTE0_BASE + 0x008)))
+#define UARTE0_EVENTS_ENDTX (*((volatile uint32_t*)(UARTE0_BASE + 0x120)))
+#define UARTE0_ENABLE     (*((volatile uint32_t*)(UARTE0_BASE + 0x500)))
+#define UARTE0_PSEL_TXD   (*((volatile uint32_t*)(UARTE0_BASE + 0x50C)))
+#define UARTE0_BAUDRATE   (*((volatile uint32_t*)(UARTE0_BASE + 0x524)))
+#define UARTE0_TXD_PTR    (*((volatile uint32_t*)(UARTE0_BASE + 0x544)))
+#define UARTE0_TXD_MAXCNT (*((volatile uint32_t*)(UARTE0_BASE + 0x548)))
+
+/* TX pin = P0.6 on nRF52840 DK */
+#define UART_TX_PIN  6
+#define BAUD_115200  0x01D7E000UL
+
+#define STACK_SIZE   256
+
+static uint32_t tx_stack[STACK_SIZE];
+static uint32_t idle_stack[STACK_SIZE];
+static ktos_tcb_t tx_tcb;
+static ktos_tcb_t idle_tcb;
+
+static void uart_init(void) {
+    UARTE0_PSEL_TXD   = UART_TX_PIN;
+    UARTE0_BAUDRATE   = BAUD_115200;
+    UARTE0_ENABLE     = 8; /* Enable UARTE */
+}
+
+static void uart_send(const char *str) {
+    uint32_t len = strlen(str);
+    UARTE0_EVENTS_ENDTX = 0;
+    UARTE0_TXD_PTR      = (uint32_t)str;
+    UARTE0_TXD_MAXCNT   = len;
+    UARTE0_STARTTX      = 1;
+    while (!UARTE0_EVENTS_ENDTX) {}
+}
+
+static void uart_task(void *arg) {
+    (void)arg;
+    uart_init();
+    while (1) {
+        uart_send("KTOS NRF52840 UART\r\n");
+        ktos_delay(500);
+    }
+}
+
+static void idle_task(void *arg) {
+    (void)arg;
+    while (1) {
+        __asm volatile ("wfe");
+        ktos_yield();
+    }
+}
+
+int main(void) {
+    ktos_init();
+    ktos_task_create(&tx_tcb,   uart_task, NULL, tx_stack,   STACK_SIZE);
+    ktos_task_create(&idle_tcb, idle_task, NULL, idle_stack, STACK_SIZE);
+    ktos_start();
+    while (1) {}
+}


### PR DESCRIPTION
## Auto-generated BSP

MCU: `NRF52840`

Generated by KTOS portal via Claude API.

- [ ] CI build passes
- [ ] Tested on hardware