### PR TITLE
fix: correct Doxygen @param name in ktos_Sleep to match function sign…

### DIFF
--- a/core/ktos.h
+++ b/core/ktos.h
@@ -302,7 +302,7 @@ bool ktos_SendMsg(struct ktos_TASK   *Task,
  *                          - @c 0       — yield immediately (run other tasks once, then resume).
  *                          - @c 1–65534 — sleep for that many milliseconds.
  *                          - @c KTOS_MSG_SLEEP_INDEFINITLY — sleep indefinitely until ktos_WakeUp() is called.
- * @param TaskSwitchPermit  @c ALLOW_TASK_SWITCH (1) — allow other tasks to run while sleeping.
+ * @param TaskAllowSwitch   @c ALLOW_TASK_SWITCH (1) — allow other tasks to run while sleeping.
  *                          @c HALT_TASK_SWITCH (0) — freeze scheduler; only this task
  *                          can resume (requires ISR to call ktos_WakeUp()).
  * @return                  The @c TaskTypeWakeUp value supplied by the ktos_WakeUp() call that


### PR DESCRIPTION
…ature

@param TaskSwitchPermit did not match actual parameter TaskAllowSwitch, causing Doxygen CI to error with 'argument not found in argument list'.

## Description
<!-- Provide a brief description of your changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition or update

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Tested on hardware platform: <!-- specify which MCU/board -->
- [ ] Unit tests added/updated
- [ ] All existing tests pass
- [ ] Code compiles without warnings

**Test Configuration**:
* MCU/Platform:
* Compiler version:
* Toolchain:

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the pull request here -->

## Related Issues
<!-- Link related issues below. Use "Closes #XX" if this PR closes an issue -->
