### PR TITLE
feat: add STM32F103C8 BSP and examples [auto-generated]

### DIFF
--- a/bsp/stm32f103c8/Makefile
+++ b/bsp/stm32f103c8/Makefile
@@ -1,0 +1,20 @@
+CC      = arm-none-eabi-gcc
+AR      = arm-none-eabi-ar
+CFLAGS  = -mcpu=cortex-m3 -mthumb -O2 -Wall -ffunction-sections -fdata-sections
+CFLAGS += -I../../include
+SRC     = ktos_bsp.c
+OBJ     = $(SRC:.c=.o)
+LIB     = libktos_bsp.a
+
+all: $(LIB)
+
+$(LIB): $(OBJ)
+	$(AR) rcs $@ $^
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJ) $(LIB)
+
+.PHONY: all clean

--- a/bsp/stm32f103c8/ktos_bsp.c
+++ b/bsp/stm32f103c8/ktos_bsp.c
@@ -1,0 +1,81 @@
+#include <stdint.h>
+#include "ktos.h"
+
+#define SYST_CSR   (*((volatile uint32_t *)0xE000E010))
+#define SYST_RVR   (*((volatile uint32_t *)0xE000E014))
+#define SYST_CVR   (*((volatile uint32_t *)0xE000E018))
+#define ICSR       (*((volatile uint32_t *)0xE000ED04))
+#define SHPR3      (*((volatile uint32_t *)0xE000ED20))
+#define SYSTICK_HZ 1000
+#define SYS_CLOCK  72000000UL
+
+void ktos_hal_DisableInterrupts(void) {
+    __asm volatile ("CPSID I");
+}
+
+void ktos_hal_EnableInterrupts(void) {
+    __asm volatile ("CPSIE I");
+}
+
+uint32_t *ktos_hal_InitTaskStack(uint32_t *stack_top, void (*task_func)(void)) {
+    stack_top--;
+    *stack_top-- = 0x01000000;          /* xPSR: thumb bit */
+    *stack_top-- = (uint32_t)task_func; /* PC */
+    *stack_top-- = 0xFFFFFFFD;          /* LR: EXC_RETURN */
+    *stack_top-- = 0x12121212;          /* R12 */
+    *stack_top-- = 0x03030303;          /* R3 */
+    *stack_top-- = 0x02020202;          /* R2 */
+    *stack_top-- = 0x01010101;          /* R1 */
+    *stack_top-- = 0x00000000;          /* R0 */
+    *stack_top-- = 0x11111111;          /* R11 */
+    *stack_top-- = 0x10101010;          /* R10 */
+    *stack_top-- = 0x09090909;          /* R9 */
+    *stack_top-- = 0x08080808;          /* R8 */
+    *stack_top-- = 0x07070707;          /* R7 */
+    *stack_top-- = 0x06060606;          /* R6 */
+    *stack_top-- = 0x05050505;          /* R5 */
+    *stack_top   = 0x04040404;          /* R4 */
+    return stack_top;
+}
+
+__attribute__((naked)) void ktos_hal_ContextSwitch(void) {
+    __asm volatile (
+        "PUSH {R4-R11}\n"
+        "LDR  R0, =ktos_current_task\n"
+        "LDR  R1, [R0]\n"
+        "STR  SP, [R1]\n"
+        "LDR  R0, =ktos_next_task\n"
+        "LDR  R1, [R0]\n"
+        "LDR  R0, =ktos_current_task\n"
+        "STR  R1, [R0]\n"
+        "LDR  SP, [R1]\n"
+        "POP  {R4-R11}\n"
+        "BX   LR\n"
+    );
+}
+
+void PendSV_Handler(void) __attribute__((alias("ktos_hal_ContextSwitch")));
+
+void SysTick_Handler(void) {
+    ktos_tick();
+    ICSR = (1u << 28);
+}
+
+void ktos_hal_InitSystemTimer(void) {
+    SHPR3 |= (0xFF << 16);
+    SYST_RVR = (SYS_CLOCK / SYSTICK_HZ) - 1;
+    SYST_CVR = 0;
+    SYST_CSR = 0x07;
+}
+
+__attribute__((naked)) void ktos_hal_StartScheduler(void) {
+    __asm volatile (
+        "LDR  R0, =ktos_current_task\n"
+        "LDR  R1, [R0]\n"
+        "LDR  SP, [R1]\n"
+        "POP  {R4-R11}\n"
+        "POP  {R0-R3, R12, LR}\n"
+        "ADD  SP, SP, #4\n"
+        "POP  {PC}\n"
+    );
+}

--- a/examples/stm32f103c8/led_control/platformio.ini
+++ b/examples/stm32f103c8/led_control/platformio.ini
@@ -1,0 +1,13 @@
+[env:bluepill_f103c8]
+platform      = ststm32
+board         = bluepill_f103c8
+framework     = none
+build_flags   =
+    -mcpu=cortex-m3
+    -mthumb
+    -O2
+    -Wall
+    -DSTM32F103C8
+    -Isrc
+upload_protocol = stlink
+monitor_speed   = 115200

--- a/examples/stm32f103c8/led_control/src/main.c
+++ b/examples/stm32f103c8/led_control/src/main.c
@@ -1,0 +1,44 @@
+#include <stdint.h>
+#include "ktos.h"
+
+#define RCC_APB2ENR  (*((volatile uint32_t *)0x40021018))
+#define GPIOC_CRH    (*((volatile uint32_t *)0x40011004))
+#define GPIOC_ODR    (*((volatile uint32_t *)0x4001100C))
+#define LED_PIN      13
+
+#define STACK_SIZE 128
+static uint32_t task1_stack[STACK_SIZE];
+static uint32_t task2_stack[STACK_SIZE];
+
+static void delay(volatile uint32_t n) {
+    while (n--) __asm volatile ("NOP");
+}
+
+static void led_on_task(void) {
+    for (;;) {
+        GPIOC_ODR &= ~(1u << LED_PIN);
+        delay(500000);
+        ktos_yield();
+    }
+}
+
+static void led_off_task(void) {
+    for (;;) {
+        GPIOC_ODR |= (1u << LED_PIN);
+        delay(500000);
+        ktos_yield();
+    }
+}
+
+int main(void) {
+    RCC_APB2ENR |= (1u << 4);
+    GPIOC_CRH   &= ~(0xFu << 20);
+    GPIOC_CRH   |=  (0x2u << 20);
+
+    ktos_init();
+    ktos_task_create(led_on_task,  task1_stack, STACK_SIZE);
+    ktos_task_create(led_off_task, task2_stack, STACK_SIZE);
+    ktos_hal_InitSystemTimer();
+    ktos_hal_StartScheduler();
+    for (;;);
+}

--- a/examples/stm32f103c8/uart/platformio.ini
+++ b/examples/stm32f103c8/uart/platformio.ini
@@ -1,0 +1,13 @@
+[env:bluepill_f103c8]
+platform      = ststm32
+board         = bluepill_f103c8
+framework     = none
+build_flags   =
+    -mcpu=cortex-m3
+    -mthumb
+    -O2
+    -Wall
+    -DSTM32F103C8
+    -Isrc
+upload_protocol = stlink
+monitor_speed   = 9600

--- a/examples/stm32f103c8/uart/src/main.c
+++ b/examples/stm32f103c8/uart/src/main.c
@@ -1,0 +1,58 @@
+#include <stdint.h>
+#include "ktos.h"
+
+#define RCC_APB2ENR  (*((volatile uint32_t *)0x40021018))
+#define GPIOA_CRH    (*((volatile uint32_t *)0x40010804))
+#define USART1_SR    (*((volatile uint32_t *)0x40013800))
+#define USART1_DR    (*((volatile uint32_t *)0x40013804))
+#define USART1_BRR   (*((volatile uint32_t *)0x40013808))
+#define USART1_CR1   (*((volatile uint32_t *)0x4001380C))
+
+#define STACK_SIZE 128
+static uint32_t tx_stack[STACK_SIZE];
+static uint32_t rx_stack[STACK_SIZE];
+
+static void uart_init(void) {
+    RCC_APB2ENR |= (1u << 14) | (1u << 2);
+    GPIOA_CRH   &= ~(0xFFu << 4);
+    GPIOA_CRH   |=  (0x4Bu << 4);
+    USART1_BRR   = 0x1D4C;   /* 9600 baud @ 72 MHz: 72000000/9600 = 7500 = 0x1D4C */
+    USART1_CR1   = (1u << 13) | (1u << 3) | (1u << 2);
+}
+
+static void uart_putc(char c) {
+    while (!(USART1_SR & (1u << 7)));
+    USART1_DR = (uint8_t)c;
+}
+
+static void uart_puts(const char *s) {
+    while (*s) uart_putc(*s++);
+}
+
+static void tx_task(void) {
+    for (;;) {
+        uart_puts("KTOS UART TX task running\r\n");
+        for (volatile int i = 0; i < 800000; i++);
+        ktos_yield();
+    }
+}
+
+static void rx_task(void) {
+    for (;;) {
+        if (USART1_SR & (1u << 5)) {
+            char c = (char)(USART1_DR & 0xFF);
+            uart_putc(c);
+        }
+        ktos_yield();
+    }
+}
+
+int main(void) {
+    uart_init();
+    ktos_init();
+    ktos_task_create(tx_task, tx_stack, STACK_SIZE);
+    ktos_task_create(rx_task, rx_stack, STACK_SIZE);
+    ktos_hal_InitSystemTimer();
+    ktos_hal_StartScheduler();
+    for (;;);
+}


### PR DESCRIPTION
## Auto-generated BSP

MCU: `STM32F103C8`

Generated by KTOS portal via Claude API.

- [ ] CI build passes
- [ ] Tested on hardware