### PR TITLE
feat: add STM32F411CE BSP and examples [auto-generated]

### DIFF
--- a/bsp/stm32f411ce/Makefile
+++ b/bsp/stm32f411ce/Makefile
@@ -1,0 +1,27 @@
+TARGET  = ktos_bsp_stm32f411ce
+MCU     = cortex-m4
+FPU     = -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+
+CC      = arm-none-eabi-gcc
+AR      = arm-none-eabi-ar
+
+INCDIRS = -I../../include
+
+CFLAGS  = -mcpu=$(MCU) -mthumb $(FPU) -O2 -Wall -ffunction-sections \
+           -fdata-sections $(INCDIRS) -DSTM32F411xE
+
+SRCS    = ktos_bsp.c
+OBJS    = $(SRCS:.c=.o)
+
+all: lib$(TARGET).a
+
+lib$(TARGET).a: $(OBJS)
+	$(AR) rcs $@ $^
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) lib$(TARGET).a
+
+.PHONY: all clean

--- a/bsp/stm32f411ce/ktos_bsp.c
+++ b/bsp/stm32f411ce/ktos_bsp.c
@@ -1,0 +1,88 @@
+#include <stdint.h>
+#include "ktos.h"
+
+#define SYST_CSR   (*((volatile uint32_t *)0xE000E010))
+#define SYST_RVR   (*((volatile uint32_t *)0xE000E014))
+#define SYST_CVR   (*((volatile uint32_t *)0xE000E018))
+#define SCB_ICSR   (*((volatile uint32_t *)0xE000ED04))
+#define NVIC_SHPR3 (*((volatile uint32_t *)0xE000ED20))
+
+#define SYS_CLK_HZ  96000000UL
+#define TICK_HZ     1000UL
+
+void ktos_hal_DisableInterrupts(void) {
+    __asm volatile ("cpsid i" ::: "memory");
+}
+
+void ktos_hal_EnableInterrupts(void) {
+    __asm volatile ("cpsie i" ::: "memory");
+}
+
+uint32_t *ktos_hal_InitTaskStack(uint32_t *stack_top, void (*task_func)(void)) {
+    stack_top--;
+    *stack_top = 0x01000000;        /* xPSR: Thumb bit */
+    stack_top--;
+    *stack_top = (uint32_t)task_func; /* PC */
+    stack_top--;
+    *stack_top = 0xFFFFFFFD;        /* LR: EXC_RETURN */
+    stack_top--;
+    *stack_top = 0x12121212;        /* R12 */
+    stack_top--;
+    *stack_top = 0x03030303;        /* R3 */
+    stack_top--;
+    *stack_top = 0x02020202;        /* R2 */
+    stack_top--;
+    *stack_top = 0x01010101;        /* R1 */
+    stack_top--;
+    *stack_top = 0x00000000;        /* R0 */
+    stack_top--;
+    *stack_top = 0x11111111;        /* R11 */
+    stack_top--;
+    *stack_top = 0x10101010;        /* R10 */
+    stack_top--;
+    *stack_top = 0x09090909;        /* R9 */
+    stack_top--;
+    *stack_top = 0x08080808;        /* R8 */
+    stack_top--;
+    *stack_top = 0x07070707;        /* R7 */
+    stack_top--;
+    *stack_top = 0x06060606;        /* R6 */
+    stack_top--;
+    *stack_top = 0x05050505;        /* R5 */
+    stack_top--;
+    *stack_top = 0x04040404;        /* R4 */
+    return stack_top;
+}
+
+__attribute__((naked)) void ktos_hal_ContextSwitch(void) {
+    __asm volatile (
+        "push {r4-r11}          \n"
+        "ldr  r0, =ktos_current_tcb \n"
+        "ldr  r1, [r0]          \n"
+        "str  sp, [r1]          \n"
+        "bl   ktos_SelectNextTask \n"
+        "ldr  r0, =ktos_current_tcb \n"
+        "ldr  r1, [r0]          \n"
+        "ldr  sp, [r1]          \n"
+        "pop  {r4-r11}          \n"
+        "bx   lr                \n"
+    );
+}
+
+void SysTick_Handler(void) {
+    ktos_hal_ContextSwitch();
+}
+
+void ktos_hal_InitSystemTimer(void) {
+    uint32_t reload = (SYS_CLK_HZ / TICK_HZ) - 1UL;
+    NVIC_SHPR3 |= (0xFF << 24);
+    SYST_CVR   = 0;
+    SYST_RVR   = reload;
+    SYST_CSR   = 0x07;
+}
+
+void ktos_hal_StartScheduler(void) {
+    ktos_hal_InitSystemTimer();
+    ktos_hal_EnableInterrupts();
+    while (1) {}
+}

--- a/examples/stm32f411ce/led_control/platformio.ini
+++ b/examples/stm32f411ce/led_control/platformio.ini
@@ -1,0 +1,11 @@
+[env:blackpill_f411ce]
+platform      = ststm32
+board         = blackpill_f411ce
+framework     = none
+build_flags   =
+    -DSTM32F411xE
+    -I../../../include
+    -I../../../bsp/stm32f411ce
+build_src_filter = +<src/>
+extra_scripts = 
+monitor_speed = 115200

--- a/examples/stm32f411ce/led_control/src/main.c
+++ b/examples/stm32f411ce/led_control/src/main.c
@@ -1,0 +1,43 @@
+#include <stdint.h>
+#include "ktos.h"
+
+#define RCC_AHB1ENR  (*((volatile uint32_t *)0x40023830))
+#define GPIOC_MODER  (*((volatile uint32_t *)0x40020800))
+#define GPIOC_ODR    (*((volatile uint32_t *)0x40020814))
+#define LED_PIN      13
+
+#define STACK_SIZE   128
+
+static uint32_t led_stack[STACK_SIZE];
+static uint32_t idle_stack[STACK_SIZE];
+
+static ktos_tcb_t led_tcb;
+static ktos_tcb_t idle_tcb;
+
+static void delay(volatile uint32_t n) {
+    while (n--) __asm volatile ("nop");
+}
+
+static void led_task(void) {
+    RCC_AHB1ENR  |= (1 << 2);
+    GPIOC_MODER  &= ~(3U << (LED_PIN * 2));
+    GPIOC_MODER  |=  (1U << (LED_PIN * 2));
+    while (1) {
+        GPIOC_ODR ^= (1 << LED_PIN);
+        delay(400000);
+    }
+}
+
+static void idle_task(void) {
+    while (1) {
+        __asm volatile ("wfi");
+    }
+}
+
+int main(void) {
+    ktos_Init();
+    ktos_CreateTask(&led_tcb,  led_task,  led_stack,  STACK_SIZE);
+    ktos_CreateTask(&idle_tcb, idle_task, idle_stack, STACK_SIZE);
+    ktos_hal_StartScheduler();
+    return 0;
+}

--- a/examples/stm32f411ce/uart/platformio.ini
+++ b/examples/stm32f411ce/uart/platformio.ini
@@ -1,0 +1,10 @@
+[env:blackpill_f411ce]
+platform      = ststm32
+board         = blackpill_f411ce
+framework     = none
+build_flags   =
+    -DSTM32F411xE
+    -I../../../include
+    -I../../../bsp/stm32f411ce
+build_src_filter = +<src/>
+monitor_speed = 115200

--- a/examples/stm32f411ce/uart/src/main.c
+++ b/examples/stm32f411ce/uart/src/main.c
@@ -1,0 +1,60 @@
+#include <stdint.h>
+#include <string.h>
+#include "ktos.h"
+
+#define RCC_AHB1ENR  (*((volatile uint32_t *)0x40023830))
+#define RCC_APB2ENR  (*((volatile uint32_t *)0x40023844))
+#define GPIOA_MODER  (*((volatile uint32_t *)0x40020000))
+#define GPIOA_AFRH   (*((volatile uint32_t *)0x40020024))
+#define USART1_SR    (*((volatile uint32_t *)0x40011000))
+#define USART1_DR    (*((volatile uint32_t *)0x40011004))
+#define USART1_BRR   (*((volatile uint32_t *)0x40011008))
+#define USART1_CR1   (*((volatile uint32_t *)0x4001100C))
+
+#define STACK_SIZE   256
+
+static uint32_t uart_stack[STACK_SIZE];
+static uint32_t idle_stack[STACK_SIZE];
+static ktos_tcb_t uart_tcb;
+static ktos_tcb_t idle_tcb;
+
+static void uart_init(void) {
+    RCC_AHB1ENR |= (1 << 0);
+    RCC_APB2ENR |= (1 << 4);
+    GPIOA_MODER &= ~(0xF << 18);
+    GPIOA_MODER |=  (0xA << 18);
+    GPIOA_AFRH  &= ~(0xFF << 4);
+    GPIOA_AFRH  |=  (0x77 << 4);
+    USART1_BRR   = 0x683;  /* 96MHz / 115200 approx */
+    USART1_CR1   = (1 << 13) | (1 << 3) | (1 << 2);
+}
+
+static void uart_puts(const char *s) {
+    while (*s) {
+        while (!(USART1_SR & (1 << 7))) {}
+        USART1_DR = (uint32_t)(*s++);
+    }
+}
+
+static void uart_task(void) {
+    uart_init();
+    while (1) {
+        uart_puts("KTOS running on STM32F411CE\r\n");
+        volatile uint32_t d = 500000;
+        while (d--) __asm volatile ("nop");
+    }
+}
+
+static void idle_task(void) {
+    while (1) {
+        __asm volatile ("wfi");
+    }
+}
+
+int main(void) {
+    ktos_Init();
+    ktos_CreateTask(&uart_tcb, uart_task, uart_stack, STACK_SIZE);
+    ktos_CreateTask(&idle_tcb, idle_task, idle_stack, STACK_SIZE);
+    ktos_hal_StartScheduler();
+    return 0;
+}


### PR DESCRIPTION
## Auto-generated BSP

MCU: `STM32F411CE`

Generated by KTOS portal via Claude API.

- [ ] CI build passes
- [ ] Tested on hardware